### PR TITLE
Add bool type

### DIFF
--- a/sigma/types.py
+++ b/sigma/types.py
@@ -309,6 +309,20 @@ class SigmaNumber(SigmaType):
             return self.number == other.number
 
 @dataclass
+class SigmaBool(SigmaType):
+    """boolean value type"""
+    boolean : bool
+
+    def __post_init__(self):
+        if not isinstance(self.boolean, bool):
+            raise SigmaTypeError("SigmaBool must be a boolean")
+
+    def __str__(self):
+        return str(self.boolean)
+
+
+
+@dataclass
 class SigmaRegularExpression(SigmaType):
     """Regular expression type"""
     regexp : str


### PR DESCRIPTION
HI,
Last week I had to fix rule with a bool value in yaml because many backend in sigmac don't manage it.
So I think to add a type SigmaBool.
Next is to think how deal with.
- It should be only a equal (no contains, start....).
- Backend that don't support convert SigmaBool to SigmaString 
