### PR TITLE
fix prefix transformation

### DIFF
--- a/sigma/processing/transformations.py
+++ b/sigma/processing/transformations.py
@@ -206,7 +206,8 @@ class AddFieldnamePrefixTransformation(DetectionItemTransformation):
     prefix : str
 
     def apply_detection_item(self, detection_item : SigmaDetectionItem):
-        detection_item.field = self.prefix + detection_item.field
+        if type(detection_item.field) is str:
+            detection_item.field = self.prefix + detection_item.field
         self.processing_item_applied(detection_item)
 
 @dataclass


### PR DESCRIPTION
While playing around I found out that AddFieldnamePrefixTransformation with this [rule](https://github.com/SigmaHQ/sigma/blob/master/rules/windows/dns_query/dns_query_win_possible_dns_rebinding.yml) was causing a crash:


**prefix.yml:**
```yaml
---
name: test-prefix
transformations:
  - id: "Test"
    type: "field_name_prefix"
    prefix: "myprefix_"
```
```bash
sigma convert -t splunk -p prefix.yml ./rules/windows/dns_query/dns_query_win_possible_dns_rebinding.yml
```

With this PR this should be fixed