### PR TITLE
Fix: convert_rule method handling optional output_format argument

### DIFF
--- a/sigma/conversion/base.py
+++ b/sigma/conversion/base.py
@@ -92,7 +92,7 @@ class Backend(ABC):
                 for cond in rule.detection.parsed_condition
             ]
             return [                                    # 3. Postprocess generated query
-                self.finalize_query(rule, query, index, state, output_format)
+                self.finalize_query(rule, query, index, state, output_format or self.default_format)
                 for index, query in enumerate(queries)
             ]
         except SigmaError as e:


### PR DESCRIPTION
# Overview
Noticed when testing pySigma's default backend rule conversion functionality that converting a single rule using convert_rule() method did not work.
# Testing
My test code was:
```python
import sigma, yaml
from sigma.collection import SigmaCollection
from sigma.rule import SigmaRule
from sigma.backends.test import backend

# generic backend
generic_backend = backend.TextQueryTestBackend()

# load some rules
dns_rules = [r"C:\something\dns_query\dns_query_win_mega_nz.yml",
             r"C:\something\dns_query\dns_query_win_tor_onion.yml",
             r"C:\something\dns_query\dns_query_win_susp_teamviewer.yml"]

dns_rule_collection = SigmaCollection.load_ruleset(dns_rules)

# convert rules
print("Converting rules!")
for rule in dns_rule_collection.rules:
    print("--------------------------")
    print(rule.title)
    print("--Generic conversion: \t\t{}".format(generic_backend.convert_rule(rule)))
```
This resulted in the following output:
```python
Converting rules!
--------------------------
DNS Query for MEGA.io Upload Domain
Traceback (most recent call last):
  File "H:\Tools\Sigma\sigma_testing.py", line 43, in <module>
    print("--Generic conversion: \t\t{}".format(generic_backend.convert_rule(rule)))
  File "H:\Tools\Sigma\pySigma\sigma\conversion\base.py", line 94, in convert_rule
    return [                                    # 3. Postprocess generated query
  File "H:\Tools\Sigma\pySigma\sigma\conversion\base.py", line 95, in <listcomp>
    self.finalize_query(rule, query, index, state, output_format) # or self.default_format)
  File "H:\Tools\Sigma\pySigma\sigma\conversion\base.py", line 543, in finalize_query
    return super().finalize_query(rule, query, index, state, output_format)
  File "H:\Tools\Sigma\pySigma\sigma\conversion\base.py", line 248, in finalize_query
    return self.__getattribute__("finalize_query_" + output_format)(rule, query, index, state)
TypeError: can only concatenate str (not "NoneType") to str
```
After making the minor fix (which I just borrowed from the convert() method, the output was successful:
```python
Converting rules!
--------------------------
DNS Query for MEGA.io Upload Domain
--Generic conversion: 		['QueryName="*userstorage.mega.co.nz*"']
--------------------------
Query Tor Onion Address
--Generic conversion: 		['QueryName="*.onion*"']
--------------------------
Suspicious TeamViewer Domain Access
--Generic conversion: 		['QueryName in ("taf.teamviewer.com", "udp.ping.teamviewer.com") and not Image="*TeamViewer*"']
```
