### PR TITLE
Fixes: missing of them and unescaped regular expressions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pySigma"
-version = "0.4.2"
+version = "0.4.3"
 license = "LGPL-2.1-only"
 description = "Sigma rule processing and conversion tools"
 authors = ["Thomas Patzke <thomas@patzke.org>"]

--- a/sigma/conditions.py
+++ b/sigma/conditions.py
@@ -140,7 +140,12 @@ class ConditionSelector(ConditionItem):
     def postprocess(self, detections : "sigma.rule.SigmaDetections", parent : Optional["ConditionItem"] = None, source : Optional[SigmaRuleLocation] = None) -> Union[ConditionAND, ConditionOR]:
         """Converts selector into an AND or OR condition"""
         self.parent = parent
-        r = re.compile(self.pattern.replace("*", ".*"))
+
+        if self.pattern == "them":
+            r = re.compile(".*")
+        else:
+            r = re.compile(self.pattern.replace("*", ".*"))
+
         ids = [
             ConditionIdentifier([ identifier ])
             for identifier in detections.detections.keys()

--- a/sigma/modifiers.py
+++ b/sigma/modifiers.py
@@ -146,7 +146,7 @@ class SigmaRegularExpressionModifier(SigmaValueModifier):
     def modify(self, val : SigmaString) -> SigmaRegularExpression:
         if len(self.applied_modifiers) > 0:
             raise SigmaValueError("Regular expression modifier only applicable to unmodified values", source=self.source)
-        return SigmaRegularExpression(str(val))
+        return SigmaRegularExpression(val.original)
 
 class SigmaCIDRModifier(SigmaValueModifier):
     def modify(self, val : SigmaString) -> SigmaCIDRExpression:

--- a/sigma/types.py
+++ b/sigma/types.py
@@ -58,6 +58,7 @@ class SigmaString(SigmaType):
     """
     Strings in Sigma detection values containing wildcards.
     """
+    original : str  # the original string, untouched
     s : Tuple[Union[str, SpecialChars, Placeholder]]      # the string is represented as sequence of strings and characters with special meaning
 
     def __init__(self, s : Optional[str] = None):
@@ -70,6 +71,9 @@ class SigmaString(SigmaType):
         """
         if s is None:
             s = ""
+
+        self.original = s
+
         r = list()
         acc = ""            # string accumulation until special character appears
         escaped = False     # escape mode flag: characters in this mode are always accumulated

--- a/tests/test_conditions.py
+++ b/tests/test_conditions.py
@@ -164,6 +164,15 @@ def test_selector_1_parent_chain_classes(sigma_simple_detections):
     assert SigmaCondition("1 of detection*", sigma_simple_detections) \
         .parsed.args[0].parent_chain_classes() == [SigmaDetectionItem, SigmaDetection, ConditionIdentifier, ConditionOR]
 
+def test_selector_1_of_them(sigma_simple_detections):
+    assert SigmaCondition("1 of them", sigma_simple_detections).parsed == ConditionOR([
+        ConditionValueExpression(SigmaString("val1")),
+        ConditionValueExpression(SigmaString("val2")),
+        ConditionValueExpression(SigmaString("val3")),
+        ConditionValueExpression(SigmaString("val4")),
+        ConditionValueExpression(SigmaString("other")),
+    ])
+
 def test_selector_any(sigma_simple_detections):
     assert SigmaCondition("any of detection*", sigma_simple_detections).parsed == ConditionOR([
         ConditionValueExpression(SigmaString("val1")),
@@ -172,12 +181,30 @@ def test_selector_any(sigma_simple_detections):
         ConditionValueExpression(SigmaString("val4")),
     ])
 
+def test_selector_any_of_them(sigma_simple_detections):
+    assert SigmaCondition("any of them", sigma_simple_detections).parsed == ConditionOR([
+        ConditionValueExpression(SigmaString("val1")),
+        ConditionValueExpression(SigmaString("val2")),
+        ConditionValueExpression(SigmaString("val3")),
+        ConditionValueExpression(SigmaString("val4")),
+        ConditionValueExpression(SigmaString("other")),
+    ])
+
 def test_selector_all(sigma_simple_detections):
     assert SigmaCondition("all of detection*", sigma_simple_detections).parsed == ConditionAND([
         ConditionValueExpression(SigmaString("val1")),
         ConditionValueExpression(SigmaString("val2")),
         ConditionValueExpression(SigmaString("val3")),
         ConditionValueExpression(SigmaString("val4")),
+    ])
+
+def test_selector_all_of_them(sigma_simple_detections):
+    assert SigmaCondition("all of them", sigma_simple_detections).parsed == ConditionAND([
+        ConditionValueExpression(SigmaString("val1")),
+        ConditionValueExpression(SigmaString("val2")),
+        ConditionValueExpression(SigmaString("val3")),
+        ConditionValueExpression(SigmaString("val4")),
+        ConditionValueExpression(SigmaString("other")),
     ])
 
 def test_keyword_detection(sigma_detections):

--- a/tests/test_modifiers.py
+++ b/tests/test_modifiers.py
@@ -127,6 +127,9 @@ def test_wide_noascii(dummy_detection_item):
 def test_re(dummy_detection_item):
     assert SigmaRegularExpressionModifier(dummy_detection_item, []).modify(SigmaString("foo?bar.*")) == SigmaRegularExpression("foo?bar.*")
 
+def test_do_not_escape_regular_expressions(dummy_detection_item):
+    assert SigmaRegularExpressionModifier(dummy_detection_item, []).modify(SigmaString(r"foo\\bar")) == SigmaRegularExpression(r"foo\\bar")
+
 def test_re_contains(dummy_detection_item):
     assert SigmaContainsModifier(dummy_detection_item, []).modify(SigmaRegularExpression("foo?bar")) == SigmaRegularExpression(".*foo?bar.*")
 


### PR DESCRIPTION
Proposing changes to fix two regressions when compared to sigmatools (in different commits)

* The `of them` form of condition is currently missing
* Regular Expressions are incorrectly being unescaped

Tests were added to cover these use cases.