### PR TITLE
fix: do not accept invalid conditions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pySigma"
-version = "0.4.3"
+version = "0.4.4"
 license = "LGPL-2.1-only"
 description = "Sigma rule processing and conversion tools"
 authors = ["Thomas Patzke <thomas@patzke.org>"]

--- a/sigma/conditions.py
+++ b/sigma/conditions.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass, field
 from abc import ABC
 import re
 from sigma.processing.tracking import ProcessingItemTrackingMixin
-from pyparsing import Word, alphanums, Keyword, infix_notation, opAssoc, ParseResults
+from pyparsing import Word, alphanums, Keyword, infix_notation, opAssoc, ParseResults, ParseException
 from typing import ClassVar, List, Optional, Union, Type
 from sigma.types import SigmaType
 from sigma.exceptions import SigmaConditionError, SigmaRuleLocation
@@ -205,8 +205,11 @@ class SigmaCondition(ProcessingItemTrackingMixin):
         reflected. It turned out, that the access time is most appropriate. No caching is done to reflect the current
         state of the rule.
         """
-        parsed = condition.parseString(self.condition)[0]
-        return parsed.postprocess(self.detections, source=self.source)
+        try:
+            parsed = condition.parseString(self.condition, parse_all=True)[0]
+            return parsed.postprocess(self.detections, source=self.source)
+        except ParseException as e:
+            raise SigmaConditionError(str(e))
 
 ConditionType = Union[
     ConditionOR,

--- a/tests/test_conditions.py
+++ b/tests/test_conditions.py
@@ -270,3 +270,13 @@ def test_undefined_identifier(sigma_simple_detections):
 def test_null_keyword(sigma_invalid_detections):
     with pytest.raises(SigmaConditionError):
         SigmaCondition("null-keyword", sigma_invalid_detections).parsed
+
+
+@pytest.mark.parametrize("condition", [
+    "detection1 and",
+    "detection1 and (detection2 OR detection3)",
+    "detection1 and not (detection2 OR detection3)",
+])
+def test_invalid_conditions(condition, sigma_simple_detections):
+    with pytest.raises(SigmaConditionError):
+        SigmaCondition(condition, sigma_simple_detections).parsed


### PR DESCRIPTION
The library is currently silently accepting invalid conditions.

For example, both `selection1 and` and `selection1 and (selection2 OR selection3)` are both invalid and silently transformed to `selection1`.

This Pull Request makes sure that an exception is raised instead in such cases.