### PR TITLE
Fix: encoding issue in SigmaCollection.load_ruleset() method in collection.py

### DIFF
--- a/sigma/collection.py
+++ b/sigma/collection.py
@@ -146,7 +146,7 @@ class SigmaCollection:
             if on_beforeload is not None:       # replace path with return value of on_beforeload function if provided
                 path = on_beforeload(path)
             if path is not None:                # Skip if path is None
-                sigma_collection = SigmaCollection.from_yaml(path.open(), collect_errors, SigmaRuleLocation(path))
+                sigma_collection = SigmaCollection.from_yaml(path.open(encoding="utf-8"), collect_errors, SigmaRuleLocation(path))
                 if on_load is not None:         # replace SigmaCollection generated from file content with the return value from on_load function if provided
                     sigma_collection = on_load(path, sigma_collection)
                 if sigma_collection is not None:    # Skip if nothing


### PR DESCRIPTION
# Overview
When testing Sigma rules I received a character encoding-related error originating in collection.py - SigmaCollection.load_ruleset() method.

# Test Code
My test script was:
```python
import sigma
from sigma.collection import SigmaCollection
from sigma.backends.test import backend

# generic backend
generic_backend = backend.TextQueryTestBackend()

# load some rules
process_start_rules = [r"...\<sigma_rule_path>\rules\windows\process_creation\proc_creation_win_anydesk_silent_install.yml"]
process_start_rule_collection = SigmaCollection.load_ruleset(process_start_rules)

for rule in process_start_rule_collection.rules:
    print(rule.title + " conversion:")
    print(generic_backend.convert_rule(rule)[0])
    print("\n")
```

This yielded an error traceback ending in:
```python
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8d in position 115: character maps to <undefined>
```

# Analysis
I believe this is due to the fact that the rule in question contains non-ASCII special characters (```author: Ján Trenčanský```) which are not decoding correctly. Specifying utf-8 encoding when opening the file fixes the problem. After doing so, the above code resulted in the output:

```
AnyDesk Silent Installation conversion:
CommandLine="*--install*" and CommandLine="*--start-with-win*" and CommandLine="*--silent*"
```