### PR TITLE
Fix crash at calling `startswith`/`endswith` on empty strings

### DIFF
--- a/sigma/types.py
+++ b/sigma/types.py
@@ -316,6 +316,8 @@ class SigmaString(SigmaType):
 
     def startswith(self, val : Union[str, SpecialChars]) -> bool:
         """Check if string starts with a given string or special character."""
+        if len(self.s) == 0:
+            return False
         c = self.s[0]
         if not isinstance(val, type(c)):    # can't match if types differ
             return False
@@ -326,6 +328,8 @@ class SigmaString(SigmaType):
 
     def endswith(self, val : Union[str, SpecialChars]) -> bool:
         """Check if string ends with a given string or special character."""
+        if len(self.s) == 0:
+            return False
         c = self.s[-1]
         if not isinstance(val, type(c)):    # can't match if types differ
             return False

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -104,6 +104,7 @@ def test_strings_equal_invalid_type():
 
 def test_strings_startswith_str():
     assert SigmaString("foobar").startswith("foo")
+    assert not SigmaString("").startswith("abc")
 
 def test_strings_startswith_special():
     assert SigmaString("*foobar").startswith(SpecialChars.WILDCARD_MULTI)
@@ -113,6 +114,7 @@ def test_strings_startswith_difftypes():
 
 def test_strings_endswith_str():
     assert SigmaString("foobar").endswith("bar")
+    assert not SigmaString("").endswith("abc")
 
 def test_strings_endswith_special():
     assert SigmaString("foobar*").endswith(SpecialChars.WILDCARD_MULTI)


### PR DESCRIPTION
Was reproducible on `sigma/rules/windows/registry/registry_set/registry_set_disable_winevt_logging.yml` and few other rules