### PR TITLE
Ensure DeferredQueryExpressions avoid grouping

### DIFF
--- a/sigma/conversion/base.py
+++ b/sigma/conversion/base.py
@@ -471,7 +471,10 @@ class TextQueryBackend(Backend):
 
     def convert_condition_group(self, cond : ConditionItem, state : ConversionState) -> Union[str, DeferredQueryExpression]:
         """Group condition item."""
-        return self.group_expression.format(expr=self.convert_condition(cond, state))
+        expr = self.convert_condition(cond, state)
+        if expr is None or isinstance(expr, DeferredQueryExpression):
+            return expr
+        return self.group_expression.format(expr=expr)
 
     def convert_condition_or(self, cond : ConditionOR, state : ConversionState) -> Union[str, DeferredQueryExpression]:
         """Conversion of OR conditions."""


### PR DESCRIPTION
By formatting a DeferredQueryExpression as a string result, it causes the objects to be coerced to a str, leading to invalid queries being generated.

This commit changes the behaviour of convert_condition_group to only apply precedence grouping to non-deferred filters. This does mean that any DeferredQueryExpressions must implement precedence themselves.

Fixes issue SigmaHQ/pySigma#69.