### PR TITLE
Fixed Windows2019 poetry install error

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         os: [ 'ubuntu-20.04', 'windows-2019', 'macos-12' ]
         python-version: [ '3.8', '3.9', '3.10', '3.11' ]
-        poetry-version: [ '1.2' ]
+        poetry-version: [ '1.2.2' ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## What Changed
- updated `poetry-version` `1.2` to `1.2.2`
  -  to fix github actions error(https://github.com/SigmaHQ/pySigma/pull/73)

## Motivation and Context
Poetry install fails with win2019 + python3.9.13 + **Poetry1.2.0** as follows.
```
C:\Users\Administrator\pySigma>poetry install
Installing dependencies from lock file

Package operations: 51 installs, 0 updates, 0 removals

  • Installing pyparsing (3.0.9)
  • Installing atomicwrites (1.4.1): Failed

  CalledProcessError

  Command 'C:\Users\Administrator\AppData\Local\pypoetry\Cache\virtualenvs\pysigma-WCodCxyy-py3.9\Scripts\python.exe C:\Users\Administrator\AppData\Local\Programs\Python\Python39\lib\site-packages\virtualenv\seed\wheels\embed\pip-22.3.1-py3-none-any.whl\pip install --use-pep517 --disable-pip-version-check --prefix C:\Users\Administrator\AppData\Local\pypoetry\Cache\virtualenvs\pysigma-WCodCxyy-py3.9 --no-deps C:\Users\Administrator\AppData\Local\pypoetry\Cache\artifacts\1b\09\43\f8f36d57c7cc6f6a038e649e082fa3ea231c686664e203db89b869ada7\atomicwrites-1.4.1.tar.gz' returned non-zero exit status 1.

  at ~\AppData\Local\Programs\Python\Python39\lib\subprocess.py:528 in run
       524│             # We don't call process.wait() as .__exit__ does that for us.
       525│             raise
       526│         retcode = process.poll()
       527│         if check and retcode:
    →  528│             raise CalledProcessError(retcode, process.args,
       529│                                      output=stdout, stderr=stderr)
       530│     return CompletedProcess(process.args, retcode, stdout, stderr)
       531│
       532│

The following error occurred when trying to handle this error:


  EnvCommandError

  Command C:\Users\Administrator\AppData\Local\pypoetry\Cache\virtualenvs\pysigma-WCodCxyy-py3.9\Scripts\python.exe C:\Users\Administrator\AppData\Local\Programs\Python\Python39\lib\site-packages\virtualenv\seed\wheels\embed\pip-22.3.1-py3-none-any.whl\pip install --use-pep517 --disable-pip-version-check --prefix C:\Users\Administrator\AppData\Local\pypoetry\Cache\virtualenvs\pysigma-WCodCxyy-py3.9 --no-deps C:\Users\Administrator\AppData\Local\pypoetry\Cache\artifacts\1b\09\43\f8f36d57c7cc6f6a038e649e082fa3ea231c686664e203db89b869ada7\atomicwrites-1.4.1.tar.gz errored with the following return code 1, and output:
  Processing c:\users\administrator\appdata\local\pypoetry\cache\artifacts\1b\09\43\f8f36d57c7cc6f6a038e649e082fa3ea231c686664e203db89b869ada7\atomicwrites-1.4.1.tar.gz
    Installing build dependencies: started
    Installing build dependencies: finished with status 'done'
  ERROR: Could not install packages due to an OSError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\2\\tmph670ww_u_in_process.py'
  Check the permissions.



  at ~\AppData\Local\Programs\Python\Python39\lib\site-packages\poetry\utils\env.py:1473 in _run
      1469│                 output = subprocess.check_output(
      1470│                     command, stderr=subprocess.STDOUT, env=env, **kwargs
      1471│                 )
      1472│         except CalledProcessError as e:
    → 1473│             raise EnvCommandError(e, input=input_)
      1474│
      1475│         return decode(output)
      1476│
      1477│     def execute(self, bin: str, *args: str, **kwargs: Any) -> int:

The following error occurred when trying to handle this error:


  PoetryException

  Failed to install C:/Users/Administrator/AppData/Local/pypoetry/Cache/artifacts/1b/09/43/f8f36d57c7cc6f6a038e649e082fa3ea231c686664e203db89b869ada7/atomicwrites-1.4.1.tar.gz

  at ~\AppData\Local\Programs\Python\Python39\lib\site-packages\poetry\utils\pip.py:51 in pip_install
       47│
       48│     try:
       49│         return environment.run_pip(*args)
       50│     except EnvCommandError as e:
    →  51│         raise PoetryException(f"Failed to install {path.as_posix()}") from e
       52│

  • Installing attrs (22.1.0)
  • Installing certifi (2022.9.24)
  • Installing charset-normalizer (2.1.1)
  • Installing colorama (0.4.6)
  • Installing idna (3.4)
  • Installing iniconfig (1.1.1)
  • Installing lazy-object-proxy (1.8.0)
  • Installing markupsafe (2.1.1)
  • Installing mypy-extensions (0.4.3)
  • Installing packaging (21.3)
  • Installing pluggy (1.0.0)
  • Installing py (1.11.0)
  • Installing pytz (2022.6)
  • Installing toml (0.10.2)
  • Installing tomli (2.0.1)
  • Installing typing-extensions (4.4.0)
  • Installing urllib3 (1.26.13)
  • Installing wrapt (1.14.1)
  • Installing zipp (3.11.0)

C:\Users\Administrator\pySigma>poetry install
Installing dependencies from lock file

Package operations: 31 installs, 0 updates, 0 removals

  • Installing atomicwrites (1.4.1): Failed

  CalledProcessError

  Command 'C:\Users\Administrator\AppData\Local\pypoetry\Cache\virtualenvs\pysigma-WCodCxyy-py3.9\Scripts\python.exe C:\Users\Administrator\AppData\Local\Programs\Python\Python39\lib\site-packages\virtualenv\seed\wheels\embed\pip-22.3.1-py3-none-any.whl\pip install --use-pep517 --disable-pip-version-check --prefix C:\Users\Administrator\AppData\Local\pypoetry\Cache\virtualenvs\pysigma-WCodCxyy-py3.9 --no-deps C:\Users\Administrator\AppData\Local\pypoetry\Cache\artifacts\1b\09\43\f8f36d57c7cc6f6a038e649e082fa3ea231c686664e203db89b869ada7\atomicwrites-1.4.1.tar.gz' returned non-zero exit status 1.

  at ~\AppData\Local\Programs\Python\Python39\lib\subprocess.py:528 in run
       524│             # We don't call process.wait() as .__exit__ does that for us.
       525│             raise
       526│         retcode = process.poll()
       527│         if check and retcode:
    →  528│             raise CalledProcessError(retcode, process.args,
       529│                                      output=stdout, stderr=stderr)
       530│     return CompletedProcess(process.args, retcode, stdout, stderr)
       531│
       532│

The following error occurred when trying to handle this error:


  EnvCommandError

  Command C:\Users\Administrator\AppData\Local\pypoetry\Cache\virtualenvs\pysigma-WCodCxyy-py3.9\Scripts\python.exe C:\Users\Administrator\AppData\Local\Programs\Python\Python39\lib\site-packages\virtualenv\seed\wheels\embed\pip-22.3.1-py3-none-any.whl\pip install --use-pep517 --disable-pip-version-check --prefix C:\Users\Administrator\AppData\Local\pypoetry\Cache\virtualenvs\pysigma-WCodCxyy-py3.9 --no-deps C:\Users\Administrator\AppData\Local\pypoetry\Cache\artifacts\1b\09\43\f8f36d57c7cc6f6a038e649e082fa3ea231c686664e203db89b869ada7\atomicwrites-1.4.1.tar.gz errored with the following return code 1, and output:
  Processing c:\users\administrator\appdata\local\pypoetry\cache\artifacts\1b\09\43\f8f36d57c7cc6f6a038e649e082fa3ea231c686664e203db89b869ada7\atomicwrites-1.4.1.tar.gz
    Installing build dependencies: started
    Installing build dependencies: finished with status 'done'
  ERROR: Could not install packages due to an OSError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\2\\tmpfrb_g5fp_in_process.py'
  Check the permissions.



  at ~\AppData\Local\Programs\Python\Python39\lib\site-packages\poetry\utils\env.py:1473 in _run
      1469│                 output = subprocess.check_output(
      1470│                     command, stderr=subprocess.STDOUT, env=env, **kwargs
      1471│                 )
      1472│         except CalledProcessError as e:
    → 1473│             raise EnvCommandError(e, input=input_)
      1474│
      1475│         return decode(output)
      1476│
      1477│     def execute(self, bin: str, *args: str, **kwargs: Any) -> int:

The following error occurred when trying to handle this error:


  PoetryException

  Failed to install C:/Users/Administrator/AppData/Local/pypoetry/Cache/artifacts/1b/09/43/f8f36d57c7cc6f6a038e649e082fa3ea231c686664e203db89b869ada7/atomicwrites-1.4.1.tar.gz

  at ~\AppData\Local\Programs\Python\Python39\lib\site-packages\poetry\utils\pip.py:51 in pip_install
       47│
       48│     try:
       49│         return environment.run_pip(*args)
       50│     except EnvCommandError as e:
    →  51│         raise PoetryException(f"Failed to install {path.as_posix()}") from e
       52│
```

Poetry install suceeded with win2019 + python3.9.13 + **Poetry1.2.2** as follows.
```
C:\Users\Administrator\pySigma>pip install poetry==1.2.2
Collecting poetry==1.2.2
  Downloading poetry-1.2.2-py3-none-any.whl (212 kB)
     ---------------------------------------- 212.4/212.4 KB 12.6 MB/s eta 0:00:00
Requirement already satisfied: urllib3<2.0.0,>=1.26.0 in c:\users\administrator\appdata\local\programs\python\python39\lib\site-packages (from poetry==1.2.2) (1.26.13)
Requirement already satisfied: cachecontrol[filecache]<0.13.0,>=0.12.9 in c:\users\administrator\appdata\local\programs\python\python39\lib\site-packages (from poetry==1.2.2) (0.12.11)
Requirement already satisfied: shellingham<2.0,>=1.5 in c:\users\administrator\appdata\local\programs\python\python39\lib\site-packages (from poetry==1.2.2) (1.5.0)
Requirement already satisfied: crashtest<0.4.0,>=0.3.0 in c:\users\administrator\appdata\local\programs\python\python39\lib\site-packages (from poetry==1.2.2) (0.3.1)
Requirement already satisfied: jsonschema<5.0.0,>=4.10.0 in c:\users\administrator\appdata\local\programs\python\python39\lib\site-packages (from poetry==1.2.2) (4.17.3)
Requirement already satisfied: requests-toolbelt<0.10.0,>=0.9.1 in c:\users\administrator\appdata\local\programs\python\python39\lib\site-packages (from poetry==1.2.2) (0.9.1)
Collecting poetry-core==1.3.2
  Downloading poetry_core-1.3.2-py3-none-any.whl (531 kB)
     ---------------------------------------- 531.3/531.3 KB ? eta 0:00:00
Requirement already satisfied: keyring>=21.2.0 in c:\users\administrator\appdata\local\programs\python\python39\lib\site-packages (from poetry==1.2.2) (23.11.0)
Requirement already satisfied: tomlkit!=0.11.2,!=0.11.3,<1.0.0,>=0.11.1 in c:\users\administrator\appdata\local\programs\python\python39\lib\site-packages (from poetry==1.2.2) (0.11.6)
Requirement already satisfied: pexpect<5.0.0,>=4.7.0 in c:\users\administrator\appdata\local\programs\python\python39\lib\site-packages (from poetry==1.2.2) (4.8.0)
Requirement already satisfied: dulwich<0.21.0,>=0.20.46 in c:\users\administrator\appdata\local\programs\python\python39\lib\site-packages (from poetry==1.2.2) (0.20.50)
Requirement already satisfied: virtualenv!=20.4.5,!=20.4.6,>=20.4.3 in c:\users\administrator\appdata\local\programs\python\python39\lib\site-packages (from poetry==1.2.2) (20.17.0)
Requirement already satisfied: requests<3.0,>=2.18 in c:\users\administrator\appdata\local\programs\python\python39\lib\site-packages (from poetry==1.2.2) (2.28.1)
Requirement already satisfied: cachy<0.4.0,>=0.3.0 in c:\users\administrator\appdata\local\programs\python\python39\lib\site-packages (from poetry==1.2.2) (0.3.0)
Requirement already satisfied: platformdirs<3.0.0,>=2.5.2 in c:\users\administrator\appdata\local\programs\python\python39\lib\site-packages (from poetry==1.2.2) (2.5.4)
Requirement already satisfied: html5lib<2.0,>=1.0 in c:\users\administrator\appdata\local\programs\python\python39\lib\site-packages (from poetry==1.2.2) (1.1)
Requirement already satisfied: cleo<2.0.0,>=1.0.0a5 in c:\users\administrator\appdata\local\programs\python\python39\lib\site-packages (from poetry==1.2.2) (1.0.0a5)
Requirement already satisfied: poetry-plugin-export<2.0.0,>=1.1.2 in c:\users\administrator\appdata\local\programs\python\python39\lib\site-packages (from poetry==1.2.2) (1.1.2)
Requirement already satisfied: importlib-metadata<5.0,>=4.4 in c:\users\administrator\appdata\local\programs\python\python39\lib\site-packages (from poetry==1.2.2) (4.13.0)
Requirement already satisfied: packaging>=20.4 in c:\users\administrator\appdata\local\programs\python\python39\lib\site-packages (from poetry==1.2.2) (21.3)
Requirement already satisfied: pkginfo<2.0,>=1.5 in c:\users\administrator\appdata\local\programs\python\python39\lib\site-packages (from poetry==1.2.2) (1.9.2)
Requirement already satisfied: msgpack>=0.5.2 in c:\users\administrator\appdata\local\programs\python\python39\lib\site-packages (from cachecontrol[filecache]<0.13.0,>=0.12.9->poetry==1.2.2) (1.0.4)
Requirement already satisfied: lockfile>=0.9 in c:\users\administrator\appdata\local\programs\python\python39\lib\site-packages (from cachecontrol[filecache]<0.13.0,>=0.12.9->poetry==1.2.2) (0.12.2)
Requirement already satisfied: pylev<2.0.0,>=1.3.0 in c:\users\administrator\appdata\local\programs\python\python39\lib\site-packages (from cleo<2.0.0,>=1.0.0a5->poetry==1.2.2) (1.4.0)
Requirement already satisfied: six>=1.9 in c:\users\administrator\appdata\local\programs\python\python39\lib\site-packages (from html5lib<2.0,>=1.0->poetry==1.2.2) (1.16.0)
Requirement already satisfied: webencodings in c:\users\administrator\appdata\local\programs\python\python39\lib\site-packages (from html5lib<2.0,>=1.0->poetry==1.2.2) (0.5.1)
Requirement already satisfied: zipp>=0.5 in c:\users\administrator\appdata\local\programs\python\python39\lib\site-packages (from importlib-metadata<5.0,>=4.4->poetry==1.2.2) (3.11.0)
Requirement already satisfied: attrs>=17.4.0 in c:\users\administrator\appdata\local\programs\python\python39\lib\site-packages (from jsonschema<5.0.0,>=4.10.0->poetry==1.2.2) (22.1.0)
Requirement already satisfied: pyrsistent!=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0 in c:\users\administrator\appdata\local\programs\python\python39\lib\site-packages (from jsonschema<5.0.0,>=4.10.0->poetry==1.2.2) (0.19.2)
Requirement already satisfied: jaraco.classes in c:\users\administrator\appdata\local\programs\python\python39\lib\site-packages (from keyring>=21.2.0->poetry==1.2.2) (3.2.3)
Requirement already satisfied: pywin32-ctypes!=0.1.0,!=0.1.1 in c:\users\administrator\appdata\local\programs\python\python39\lib\site-packages (from keyring>=21.2.0->poetry==1.2.2) (0.2.0)
Requirement already satisfied: pyparsing!=3.0.5,>=2.0.2 in c:\users\administrator\appdata\local\programs\python\python39\lib\site-packages (from packaging>=20.4->poetry==1.2.2) (3.0.9)
Requirement already satisfied: ptyprocess>=0.5 in c:\users\administrator\appdata\local\programs\python\python39\lib\site-packages (from pexpect<5.0.0,>=4.7.0->poetry==1.2.2) (0.7.0)
Requirement already satisfied: charset-normalizer<3,>=2 in c:\users\administrator\appdata\local\programs\python\python39\lib\site-packages (from requests<3.0,>=2.18->poetry==1.2.2) (2.1.1)
Requirement already satisfied: certifi>=2017.4.17 in c:\users\administrator\appdata\local\programs\python\python39\lib\site-packages (from requests<3.0,>=2.18->poetry==1.2.2) (2022.9.24)
Requirement already satisfied: idna<4,>=2.5 in c:\users\administrator\appdata\local\programs\python\python39\lib\site-packages (from requests<3.0,>=2.18->poetry==1.2.2) (3.4)
Requirement already satisfied: filelock<4,>=3.4.1 in c:\users\administrator\appdata\local\programs\python\python39\lib\site-packages (from virtualenv!=20.4.5,!=20.4.6,>=20.4.3->poetry==1.2.2) (3.8.0)
Requirement already satisfied: distlib<1,>=0.3.6 in c:\users\administrator\appdata\local\programs\python\python39\lib\site-packages (from virtualenv!=20.4.5,!=20.4.6,>=20.4.3->poetry==1.2.2) (0.3.6)
Requirement already satisfied: more-itertools in c:\users\administrator\appdata\local\programs\python\python39\lib\site-packages (from jaraco.classes->keyring>=21.2.0->poetry==1.2.2) (9.0.0)
Installing collected packages: poetry-core, poetry
  Attempting uninstall: poetry-core
    Found existing installation: poetry-core 1.1.0
    Uninstalling poetry-core-1.1.0:
      Successfully uninstalled poetry-core-1.1.0
  Attempting uninstall: poetry
    Found existing installation: poetry 1.2.0
    Uninstalling poetry-1.2.0:
      Successfully uninstalled poetry-1.2.0
Successfully installed poetry-1.2.2 poetry-core-1.3.2
WARNING: You are using pip version 22.0.4; however, version 22.3.1 is available.
You should consider upgrading via the 'C:\Users\Administrator\AppData\Local\Programs\Python\Python39\python.exe -m pip install --upgrade pip' command.

C:\Users\Administrator\pySigma>poetry install
Installing dependencies from lock file

Package operations: 31 installs, 0 updates, 0 removals

  • Installing atomicwrites (1.4.1)
  • Installing alabaster (0.7.12)
  • Installing astroid (2.12.13)
  • Installing babel (2.11.0)
  • Installing coverage (6.5.0)
  • Installing dill (0.3.6)
  • Installing docutils (0.17.1)
  • Installing filelock (3.8.0)
  • Installing imagesize (1.4.1)
  • Installing importlib-metadata (5.1.0)
  • Installing isort (5.10.1)
  • Installing jinja2 (3.1.2)
  • Installing mccabe (0.7.0)
  • Installing mypy (0.931)
  • Installing platformdirs (2.5.4)
  • Installing pygments (2.13.0)
  • Installing pytest (6.2.5)
  • Installing requests (2.28.1)
  • Installing snowballstemmer (2.2.0)
  • Installing sphinxcontrib-applehelp (1.0.2)
  • Installing sphinxcontrib-devhelp (1.0.2)
  • Installing sphinxcontrib-htmlhelp (2.0.0)
  • Installing sphinxcontrib-jsmath (1.0.1)
  • Installing sphinxcontrib-qthelp (1.0.3)
  • Installing sphinxcontrib-serializinghtml (1.1.5)
  • Installing tomlkit (0.11.6)
  • Installing pylint (2.15.7)
  • Installing pytest-cov (2.12.1)
  • Installing pytest-mypy (0.6.2)
  • Installing pyyaml (6.0)
  • Installing sphinx (4.5.0)

Installing the current project: pySigma (0.8.9)
```
I would appreciate it if you could review🙏
