### PR TITLE
keep space in int

### DIFF
--- a/sigma/validators/values.py
+++ b/sigma/validators/values.py
@@ -35,7 +35,7 @@ class NumberAsStringIssue(SigmaValidationIssue):
 class NumberAsStringValidator(SigmaStringValueValidator):
     """Check numbers that were expressed as strings."""
     def validate_value(self, value: SigmaString) -> List[SigmaValidationIssue]:
-        if len(value.s) == 1 and isinstance(value.s[0], str):
+        if len(value.s) == 1 and isinstance(value.s[0], str) and not " " in value.s[0]:
             try:
                 int(value.s[0])
                 return [ NumberAsStringIssue(self.rule, value) ]


### PR DESCRIPTION
in python `int("  14") == int("14 ") == int("14") == 14` is cool.
But if in the sigma rule it is written ` 14`  it is that we are looking for the string with the space.
So add a check
get a FP when check rule https://github.com/SigmaHQ/sigma-cli/issues/8