### PR TITLE
Fixes #104 for None DetectionItems and Condition args

### DIFF
--- a/sigma/conditions.py
+++ b/sigma/conditions.py
@@ -86,7 +86,7 @@ class ConditionItem(ParentChainMixin, ABC):
         super().postprocess(detections, parent, source)
         self.args = [
             arg.postprocess(detections, self, source)
-            for arg in self.args
+            for arg in self.args if arg is not None  # Need to filter None before postprocess as well
         ]
         self.args = list(       # filter all None entries from argument list. These can be caused by empty detection items from applied transformations.
             filter(

--- a/sigma/rule.py
+++ b/sigma/rule.py
@@ -354,7 +354,7 @@ class SigmaDetection(ParentChainMixin):
             detection_item.to_plain()
             for detection_item in self.detection_items
         ]
-        # Filter out where to_plain() returns None, which causes errors merging errors.
+        # Filter out where to_plain() returns None, which causes merging errors.
         # We will have to handle the condition as well in conditions.py
         detection_items = [detection_item for detection_item in detection_items if detection_item is not None]
         detection_items_types = {   # create set of types for decision what has to be returned

--- a/sigma/rule.py
+++ b/sigma/rule.py
@@ -354,6 +354,9 @@ class SigmaDetection(ParentChainMixin):
             detection_item.to_plain()
             for detection_item in self.detection_items
         ]
+        # Filter out where to_plain() returns None, which causes errors merging errors.
+        # We will have to handle the condition as well in conditions.py
+        detection_items = [detection_item for detection_item in detection_items if detection_item is not None]
         detection_items_types = {   # create set of types for decision what has to be returned
             type(detection_item)
             for detection_item in detection_items


### PR DESCRIPTION
My original fixes in the issue were to recursively delete empty detection items within `DropDetectionItemTransformation`, however, I was able to determine what I believe is the root cause of the issue and implement the fixes in rule.py and conditions.py instead.

This removes `None` elements from detection_items when converting them to_plain(), as well as filtering out `None` conditions args before they are postprocessed.  Either one of those cases would raise different errors.