### PR TITLE
adding support for yaml converted date/datetime

### DIFF
--- a/sigma/rule.py
+++ b/sigma/rule.py
@@ -3,7 +3,7 @@ import dataclasses
 from typing import Any, Dict, Optional, Union, Sequence, List, Mapping, Type
 from uuid import UUID
 from enum import Enum, auto
-from datetime import date
+from datetime import date, datetime
 import yaml
 import sigma
 from sigma.types import SigmaType, SigmaNull, SigmaString, SigmaNumber, sigma_type
@@ -593,13 +593,14 @@ class SigmaRule(ProcessingItemTrackingMixin):
         # parse rule date if existing
         rule_date = rule.get("date")
         if rule_date is not None:
-            try:
-                rule_date = date(*(int(i) for i in rule_date.split("/")))
-            except ValueError:
+            if not isinstance(rule_date, date) and not isinstance(rule_date, datetime):
                 try:
-                    rule_date = date(*(int(i) for i in rule_date.split("-")))
+                    rule_date = date(*(int(i) for i in rule_date.split("/")))
                 except ValueError:
-                    errors.append(sigma_exceptions.SigmaDateError(f"Rule date '{ rule_date }' is invalid, must be yyyy/mm/dd or yyyy-mm-dd", source=source))
+                    try:
+                        rule_date = date(*(int(i) for i in rule_date.split("-")))
+                    except ValueError:
+                        errors.append(sigma_exceptions.SigmaDateError(f"Rule date '{ rule_date }' is invalid, must be yyyy/mm/dd or yyyy-mm-dd", source=source))
 
         # parse log source
         logsource = None

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -1,5 +1,5 @@
 import pytest
-from datetime import date
+from datetime import date, datetime
 from uuid import UUID
 from sigma import conditions
 from sigma.rule import SigmaRuleTag, SigmaLogSource, SigmaDetectionItem, SigmaDetection, SigmaDetections, SigmaStatus, SigmaLevel, SigmaRule
@@ -521,6 +521,42 @@ def test_sigmarule_bad_status():
 def test_sigmarule_bad_date():
     with pytest.raises(sigma_exceptions.SigmaDateError, match="Rule date.*test.yml"):
         SigmaRule.from_dict({ "date": "bad" }, source=sigma_exceptions.SigmaRuleLocation("test.yml"))
+def test_sigmarule_date():
+    expected_date = date(3000,1,2)
+    rule = SigmaRule.from_yaml("""
+    title: Test
+    id: cafedead-beef-0000-1111-0123456789ab
+    level: medium
+    status: test
+    date: 3000-01-02
+    logsource:
+        product: foobar
+    detection:
+        selection_1:
+            fieldA: valueA
+        condition: selection_1
+    """)
+    assert rule is not None
+    assert rule.date == expected_date
+
+def test_sigmarule_datetime():
+    expected_date = datetime(3000,1,2,3,4,5)
+    rule = SigmaRule.from_yaml("""
+    title: Test
+    id: cafedead-beef-0000-1111-123456789abc
+    level: medium
+    status: test
+    date: 3000-01-02T03:04:05
+    logsource:
+        product: foobar
+    detection:
+        selection_1:
+            fieldA: valueA
+        condition: selection_1
+    """)
+    assert rule is not None
+    assert rule.date == expected_date
+
 
 def test_sigmarule_collect_errors():
     rule = SigmaRule.from_yaml("""


### PR DESCRIPTION
The YAML importer will automatically convert some date and datetime strings to python date and datetime objects (respectively). This PR adds handling this case and associated tests cases.