### PR TITLE
Detect modules automatically

### DIFF
--- a/sigma/plugins.py
+++ b/sigma/plugins.py
@@ -51,8 +51,6 @@ class InstalledSigmaPlugins:
         result = dict()
         if include:
             for mod in pkgutil.iter_modules(module.__path__, module.__name__ + "."):
-                if ".test" in mod.name:
-                    continue
                 # attempt to merge backend directory from module into collected backend directory
                 try:
                     imported_module = importlib.import_module(mod.name)

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -4,7 +4,6 @@ from sigma.pipelines.test.pipeline import another_test_pipeline
 from sigma.plugins import SigmaPlugin, SigmaPluginDirectory, SigmaPluginState, SigmaPluginType, InstalledSigmaPlugins
 from sigma.backends.test import TextQueryTestBackend, MandatoryPipelineTestBackend
 from sigma.pipelines.test import dummy_test_pipeline
-from sigma.pipelines.sysmon import sysmon_pipeline
 import importlib.metadata
 from packaging.specifiers import Specifier
 import sigma
@@ -31,8 +30,7 @@ def test_autodiscover_pipelines():
         pipelines={
             "test": dummy_test_pipeline,
             "another_test": another_test_pipeline,
-            "sysmon": sysmon_pipeline,
-        },
+       },
         validators=dict(),
     )
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -4,6 +4,7 @@ from sigma.pipelines.test.pipeline import another_test_pipeline
 from sigma.plugins import SigmaPlugin, SigmaPluginDirectory, SigmaPluginState, SigmaPluginType, InstalledSigmaPlugins
 from sigma.backends.test import TextQueryTestBackend, MandatoryPipelineTestBackend
 from sigma.pipelines.test import dummy_test_pipeline
+from sigma.pipelines.sysmon import sysmon_pipeline
 import importlib.metadata
 from packaging.specifiers import Specifier
 import sigma
@@ -16,8 +17,8 @@ def test_autodiscover_backends():
     plugins = InstalledSigmaPlugins.autodiscover(include_pipelines=False, include_validators=False)
     assert plugins == InstalledSigmaPlugins(
         backends={
-            "test": TextQueryTestBackend,
-            "test_mandatory": MandatoryPipelineTestBackend,
+            "TextQueryTestBackend": TextQueryTestBackend,
+            "MandatoryPipelineTestBackend": MandatoryPipelineTestBackend,
         },
         pipelines=dict(),
         validators=dict(),
@@ -30,6 +31,7 @@ def test_autodiscover_pipelines():
         pipelines={
             "test": dummy_test_pipeline,
             "another_test": another_test_pipeline,
+            "sysmon": sysmon_pipeline,
         },
         validators=dict(),
     )


### PR DESCRIPTION
Hey @thomaspatzke,

As discussed in https://github.com/SigmaHQ/pySigma/discussions/110, I tried to change the code to detect the backends, validators and pipelines automatically.

My local acceptance tests worked as expected. However, there are a few issues:
1. Only the `backends` are actually automatically discovered by checking their type and superclass. The code for `validators` and `pipeplines` are roughly the same as before. I tried to dig in deeper, but there are a few nuisances:
    - Not all packages contain type hints, which hinders the use of type hints for auto-detecting pipeline functions/generators. So I added a warning for those that doesn't have type hints.
    - Due to the first point, I relied on the `pipelines` variable (`directory_name`) to find the pipeline functions, which is the same as before.
    - The `validators` follow the same logic, but I added type checking to ensure correct classes end up in the `InstalledSigmaPlugins`.
2. I tried to do it recursively by walking down the submodules when I encounter one, but it backfired due to lots of builtins and no way to check for type hints and the like. I ignored builtin, which caused pipeline functions not to be detected, because they are functions and functions are builtin.
3. I "fixed" a test to reflect for the new changes:
    - The backend names are now class names, because all the backend classes does not contain a proper `name` property.

I hope these changes align with the roadmap and future of the project, and I think it should be changed over time to compensate for the missing pieces I mentioned above.

CC: @kelnage 