### PR TITLE
Fix json serialization of SigmaLogSource

### DIFF
--- a/sigma/rule.py
+++ b/sigma/rule.py
@@ -73,7 +73,7 @@ class SigmaLogSource:
 
     def to_dict(self) -> dict:
         return {
-            field.name: value
+            field.name: str(value)
             for field in dataclasses.fields(self)
             if (value := self.__getattribute__(field.name)) is not None
         }


### PR DESCRIPTION
Hello, when trying to serialize a `SigmaRule` to json I was met with this error:

```
TypeError: Object of type SigmaRuleLocation is not JSON serializable
```

This PR converts the SigmaRuleLocation object to a string in the `to_dict` method, fixing json serialization of the dict generated by `SigmaRuleLocation.to_dict()`.