### PR TITLE
Include custom attributes in SigmaRule.to_dict()

### DIFF
--- a/sigma/rule.py
+++ b/sigma/rule.py
@@ -675,4 +675,7 @@ class SigmaRule(ProcessingItemTrackingMixin):
         if self.date is not None:
             d["date"] = self.date.isoformat()
 
+        # custom attributes
+        d.update(self.custom_attributes)
+
         return d


### PR DESCRIPTION
Hi there, SigmaRule's `from_dict` function reads any custom rule attributes and stores them in `custom_attributes`.
This PR also includes the custom attributes in the output of `to_dict`.