### PR TITLE
Distinct condition state

### DIFF
--- a/sigma/conversion/base.py
+++ b/sigma/conversion/base.py
@@ -105,23 +105,26 @@ class Backend(ABC):
         """
         Convert a single Sigma rule into the target data structure (usually query, see above).
         """
-        state = ConversionState()
         try:
             self.last_processing_pipeline = self.backend_processing_pipeline + self.processing_pipeline + self.output_format_processing_pipeline[output_format or self.default_format]
 
             error_state = "applying processing pipeline on"
             self.last_processing_pipeline.apply(rule)             # 1. Apply transformations
-            state.processing_state = self.last_processing_pipeline.state
 
+            # 2. Convert conditions
             error_state = "converting"
-            queries = [                                 # 2. Convert condition
-                self.convert_condition(cond.parsed, state)
-                for cond in rule.detection.parsed_condition
+            states = [
+                ConversionState(processing_state=self.last_processing_pipeline.state)
+                for _ in rule.detection.parsed_condition
+            ]
+            queries = [
+                self.convert_condition(cond.parsed, states[index])
+                for index, cond in enumerate(rule.detection.parsed_condition)
             ]
 
             error_state = "finalizing query for"
             return [                                    # 3. Postprocess generated query
-                self.finalize_query(rule, query, index, state, output_format or self.default_format)
+                self.finalize_query(rule, query, index, states[index], output_format or self.default_format)
                 for index, query in enumerate(queries)
             ]
         except SigmaError as e:

--- a/sigma/conversion/base.py
+++ b/sigma/conversion/base.py
@@ -114,7 +114,7 @@ class Backend(ABC):
             # 2. Convert conditions
             error_state = "converting"
             states = [
-                ConversionState(processing_state=self.last_processing_pipeline.state)
+                ConversionState(processing_state=dict(self.last_processing_pipeline.state))
                 for _ in rule.detection.parsed_condition
             ]
             queries = [

--- a/tests/test_conversion_deferred.py
+++ b/tests/test_conversion_deferred.py
@@ -83,6 +83,28 @@ def test_deferred_conversion_or(test_backend : TextQueryTestBackend):
         """)
     ) == ['fieldB="foo" or fieldC="bar" | mappedA="foo.*bar"']
 
+def test_deferred_conversion_multiple_cond(test_backend : TextQueryTestBackend):
+    assert test_backend.convert(
+        SigmaCollection.from_yaml("""
+            title: Test
+            status: test
+            logsource:
+                category: test_category
+                product: test_product
+            detection:
+                sel1:
+                    fieldA|re: foo.*bar
+                sel2:
+                    fieldB|re: foo.*
+                sel3:
+                    fieldC|re: .*bar
+                condition:
+                    - sel1
+                    - sel2
+                    - sel3
+        """)
+    ) == ['* | mappedA="foo.*bar"', '* | fieldB="foo.*"', '* | fieldC=".*bar"']
+
 def test_deferred_conversion_not(test_backend : TextQueryTestBackend):
     assert test_backend.convert(
         SigmaCollection.from_yaml("""


### PR DESCRIPTION
As highlighted in SigmaHQ/pySigma#126, a single `ConversionState` object was being shared between conversions when multiple `condition`s were present, which meant any `DeferredQueryExpression`s generated when converting those `condition`s were duplicated across all generated queries.

This commit creates a separate `ConversionState` object for each `condition`, and includes a unit test to demonstrate that it fixes SigmaHQ/pySigma#126. This change also means the conversion of each `condition` will also have its own distinct `processing_state`; I made that decision as I was unable to envisage a situation where a shared `processing_state` between conditions would be appropriate.