### PR TITLE
Fix cidr expansion for backends that use custom wildcard char

### DIFF
--- a/sigma/conversion/base.py
+++ b/sigma/conversion/base.py
@@ -1110,7 +1110,7 @@ class TextQueryBackend(Backend):
                 netmask=cidr.network.netmask,
             )
         else:  # No native CIDR support: expand into string wildcard matches on prefixes.
-            expanded = cidr.expand(self.wildcard_multi)
+            expanded = cidr.expand()
             expanded_cond = ConditionOR(
                 [
                     ConditionFieldEqualsValueExpression(cond.field, SigmaString(network))


### PR DESCRIPTION
Hello, I ran into a bug while testing the `|cidr` modifier in a backend that uses the cidr wildcard logic from `TextQueryBackend` and a wildcard character that isn't `*`.

The condition `c-ip|cidr: "10.0.0.0/8"` was converted into the following query:

```sqlite
`c-ip` LIKE '10.\%' ESCAPE '\'
```

The wildcard (`%`) should not have been escaped here.

It turns out that when `SigmaCIDRExpression.expand()` is called with a wildcard that isn't `*`, then it won't parsed as a wildcard by `SigmaString` and will therefore be escaped when the `SigmaString` is later converted back into a regular string.