### PR TITLE
Fix data sharing among class instances

### DIFF
--- a/sigma/conversion/base.py
+++ b/sigma/conversion/base.py
@@ -105,7 +105,7 @@ class Backend(ABC):
     config: Dict[str, Any]
     default_format: ClassVar[str] = "default"
     collect_errors: bool = False
-    errors: List[Tuple[SigmaRule, SigmaError]] = list()
+    errors: List[Tuple[SigmaRule, SigmaError]]
 
     # in-expressions
     convert_or_as_in: ClassVar[bool] = False  # Convert OR as in-expression
@@ -123,6 +123,7 @@ class Backend(ABC):
         collect_errors: bool = False,
     ):
         self.processing_pipeline = processing_pipeline
+        self.errors = list()
         self.collect_errors = collect_errors
 
     def convert(self, rule_collection: SigmaCollection, output_format: Optional[str] = None) -> Any:


### PR DESCRIPTION
This was a bug I encountered when testing multiple backends and this is the reason why it happened:

The `Backend.errors` property is defined as a _class variable_ and it is assigned a default value of `list`, which is mutable. This causes all the instances of this class to receive the same initialized mutable list, hence sharing the list among different instances. So, any changes to the list will be unwantedly propagated to all the instances. The following snippet shows why:

```python
# List is shared among the instance
class T:
    test = list()

t1 = T()
t2 = T()
t1.test.append(1) # This value is shared among t1 and t2.

if len(t1.test) == 1 and len(t2.test) == 1:
    print(t1.test)
    print(t2.test)
```

```python
# List is not shared among the instances
class T:
    def __init__(self):
        self.test = list()

t1 = T()
t2 = T()
t1.test.append(1) # This value is NOT shared among t1 and t2.

if len(t1.test) == 1 and len(t2.test) == 0:
    print(t1.test)
    print(t2.test)
```

CC: @kelnage @thomaspatzke 