### PR TITLE
Quick fix to rule `falsepositives` validation in `from_dict`

### DIFF
--- a/sigma/rule.py
+++ b/sigma/rule.py
@@ -718,7 +718,7 @@ class SigmaRule(ProcessingItemTrackingMixin):
 
         # validate falsepositives
         rule_falsepositives = rule.get("falsepositives")
-        if rule_falsepositives is not None and not isinstance(rule_fields, list):
+        if rule_falsepositives is not None and not isinstance(rule_falsepositives, list):
             errors.append(
                 sigma_exceptions.SigmaFalsePositivesError(
                     "Sigma rule falsepositives must be a list",


### PR DESCRIPTION
Before, `from_dict` could not load rules with `falsepositives` but not `fields` since `rule_falsepositives` would be `not None`, but `rule_fields` would be `None`, and therefore not an instance of `list`.