### PR TITLE
Fix a bug where SigmaRegularExpression.escape() was buggy when using …

### DIFF
--- a/sigma/types.py
+++ b/sigma/types.py
@@ -646,7 +646,7 @@ class SigmaRegularExpression(SigmaType):
         )
         pos = [  # determine positions of matches in regular expression
             m.start() for m in re.finditer(r, self.regexp)
-        ]
+        ] if r is not '' else []
         ranges = zip([None, *pos], [*pos, None])  # string chunk ranges with escapes in between
         ranges = list(ranges)
 

--- a/sigma/types.py
+++ b/sigma/types.py
@@ -1,5 +1,9 @@
-from math import inf
+import re
+from abc import ABC
+from dataclasses import dataclass, field
 from enum import Enum, auto
+from ipaddress import IPv4Network, IPv6Network, ip_network
+from math import inf
 from typing import (
     ClassVar,
     Dict,
@@ -14,10 +18,7 @@ from typing import (
     Callable,
     Iterator,
 )
-from abc import ABC
-from dataclasses import dataclass, field
-from enum import Enum, auto
-import re
+
 from sigma.exceptions import (
     SigmaPlaceholderError,
     SigmaRuleLocation,
@@ -25,7 +26,6 @@ from sigma.exceptions import (
     SigmaRegularExpressionError,
     SigmaTypeError,
 )
-from ipaddress import IPv4Network, IPv6Network, ip_network
 
 
 class SpecialChars(Enum):
@@ -644,9 +644,13 @@ class SigmaRegularExpression(SigmaType):
                 if e is not None
             ]
         )
-        pos = [  # determine positions of matches in regular expression
-            m.start() for m in re.finditer(r, self.regexp)
-        ] if r is not '' else []
+        pos = (
+            [  # determine positions of matches in regular expression
+                m.start() for m in re.finditer(r, self.regexp)
+            ]
+            if r is not ""
+            else []
+        )
         ranges = zip([None, *pos], [*pos, None])  # string chunk ranges with escapes in between
         ranges = list(ranges)
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -509,6 +509,18 @@ def test_re_escape_without_escape():
     )
 
 
+def test_re_escape_with_escape_escape_char_param():
+    # See issue #153 https://github.com/SigmaHQ/pySigma/issues/153
+    assert(
+        SigmaRegularExpression("bitsadmin\\.exe").escape(escape_escape_char=True)
+        == "bitsadmin\\\\.exe"
+    )
+    assert(
+        SigmaRegularExpression("bitsadmin\\.exe").escape(escape_escape_char=False)
+        == "bitsadmin\\.exe"
+    )
+
+
 def test_bool():
     assert SigmaBool(True).boolean == True
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,6 +1,14 @@
-from ipaddress import IPv4Network, IPv6Network
 import re
+from ipaddress import IPv4Network, IPv6Network
+
 import pytest
+
+from sigma.exceptions import (
+    SigmaPlaceholderError,
+    SigmaTypeError,
+    SigmaValueError,
+    SigmaRegularExpressionError,
+)
 from sigma.types import (
     SigmaBool,
     SigmaCasedString,
@@ -16,12 +24,6 @@ from sigma.types import (
     SigmaQueryExpression,
     sigma_type,
     SigmaCIDRExpression,
-)
-from sigma.exceptions import (
-    SigmaPlaceholderError,
-    SigmaTypeError,
-    SigmaValueError,
-    SigmaRegularExpressionError,
 )
 
 
@@ -511,11 +513,11 @@ def test_re_escape_without_escape():
 
 def test_re_escape_with_escape_escape_char_param():
     # See issue #153 https://github.com/SigmaHQ/pySigma/issues/153
-    assert(
+    assert (
         SigmaRegularExpression("bitsadmin\\.exe").escape(escape_escape_char=True)
         == "bitsadmin\\\\.exe"
     )
-    assert(
+    assert (
         SigmaRegularExpression("bitsadmin\\.exe").escape(escape_escape_char=False)
         == "bitsadmin\\.exe"
     )


### PR DESCRIPTION
…param escape_escape_char=False. Fixes #153

Found the bug. It was an edge case when nothing was to be escaped. The escape char would get added to every character of the regex.