### PR TITLE
Fixes syntax warning in `types.py`, plus small fixes in comments

### DIFF
--- a/sigma/types.py
+++ b/sigma/types.py
@@ -59,7 +59,7 @@ class SigmaType(ABC):
     def to_plain(self):
         """
         Return plain Python value (str, int etc.) from SigmaType instance for usage in conversion of
-        Sigma rules back to dict's. Uses the first annotated member as return value.
+        Sigma rules back to dicts. Uses the first annotated member as return value.
         """
         return self.__getattribute__(list(self.__annotations__.keys())[0])
 
@@ -448,7 +448,7 @@ class SigmaString(SigmaType):
         """
         if (
             not self.contains_placeholder()
-        ):  # return unchanged string in a list if it doesn't contains placeholders
+        ):  # return unchanged string in a list if it doesn't contain placeholders
             return [self]
 
         s = self.s
@@ -638,7 +638,7 @@ class SigmaRegularExpression(SigmaType):
         escape_escape_char) with escape_char. Prepends a (?...) expression with set flags (i, m and
         s) if flag_prefix is set."""
         r = "|".join(
-            [  # Generate regulear expressions from sequences that should be escaped and the escape char itself
+            [  # Generate regular expressions from sequences that should be escaped and the escape char itself
                 re.escape(e)
                 for e in [*escaped, escape_char if escape_escape_char else None]
                 if e is not None
@@ -648,7 +648,7 @@ class SigmaRegularExpression(SigmaType):
             [  # determine positions of matches in regular expression
                 m.start() for m in re.finditer(r, self.regexp)
             ]
-            if r is not ""
+            if r != ""
             else []
         )
         ranges = zip([None, *pos], [*pos, None])  # string chunk ranges with escapes in between

--- a/sigma/validators/base.py
+++ b/sigma/validators/base.py
@@ -15,9 +15,9 @@ class SigmaValidationIssueSeverity(Enum):
     * Low: minor improvement suggestion that results in better readability or maintainability of the
       rule.
     * Medium: issue can cause problems under certain conditions or the meaning of the rule can be
-      different than intended.
+      different from intended.
     * High: issue will cause problems. It is certain that the intention of the rule author and the
-      rule logic deviate or the rule doesn't matches anything.
+      rule logic deviate or the rule doesn't match anything.
     """
 
     LOW = auto()
@@ -171,7 +171,7 @@ class SigmaDetectionItemValidator(SigmaDetectionValidator):
         """Implementation of the detection item validation. It is invoked for each detection item.
 
         :param detection_item: detection item that should be validated.
-        :type detection: SigmaDetectionItem
+        :type detection_item: SigmaDetectionItem
         :return: List of validation issue objects describing.
         :rtype: List[SigmaValidationIssue]
         """
@@ -216,8 +216,8 @@ class SigmaValueValidator(SigmaDetectionItemValidator):
     def validate_value(self, value: SigmaType) -> List[SigmaValidationIssue]:
         """Implementation of the value validation. It is invoked for each value of a type.
 
-        :param detection_item: detection item that should be validated.
-        :type detection: SigmaDetectionItem
+        :param value: detection item that should be validated.
+        :type value: SigmaType
         :return: List of validation issue objects describing.
         :rtype: List[SigmaValidationIssue]
         """


### PR DESCRIPTION
Main issue was that the following warning was produced:

```
sigma/types.py:651: SyntaxWarning: "is not" with a literal. Did you mean "!="?
    if r is not ""
```