### PR TITLE
Remove pip Warning in is_installed

### DIFF
--- a/sigma/plugins.py
+++ b/sigma/plugins.py
@@ -331,7 +331,7 @@ class SigmaPlugin:
 
     def is_installed(self) -> bool:
         try:
-            subprocess.check_call([sys.executable, "-m", "pip", "-q", "show", self.package])
+            subprocess.check_call([sys.executable, "-m", "pip", "-qqq", "show", self.package])
             return True
         except:
             return False


### PR DESCRIPTION
Remove the pip warning from
![image](https://github.com/SigmaHQ/pySigma/assets/62423083/69b057fd-2f18-464d-8fae-8176ab3fe985)

Use pySigma 0.11.0
![image](https://github.com/SigmaHQ/pySigma/assets/62423083/f0ec3083-4c15-4953-a955-fe656ddeb1e3)
