### PR TITLE
Fix missing fields in to_dict() methods

### DIFF
--- a/sigma/correlations.py
+++ b/sigma/correlations.py
@@ -106,7 +106,9 @@ class SigmaCorrelationCondition:
         return cls(op=cond_op, count=cond_count, fieldref=cond_field, source=source)
 
     def to_dict(self) -> dict:
-        return {self.op.name.lower(): self.count}
+        if not self.fieldref:
+            return {self.op.name.lower(): self.count}
+        return {self.op.name.lower(): self.count, "field": self.fieldref}
 
 
 @dataclass

--- a/sigma/rule.py
+++ b/sigma/rule.py
@@ -1011,7 +1011,7 @@ class SigmaRuleBase:
             "title": self.title,
         }
         # Convert to string where possible
-        for field in ("id", "status", "level", "author", "description"):
+        for field in ("id", "status", "level", "author", "description", "name"):
             if (s := self.__getattribute__(field)) is not None:
                 d[field] = str(s)
 

--- a/tests/test_correlations.py
+++ b/tests/test_correlations.py
@@ -430,6 +430,17 @@ def test_correlation_condition_with_field():
     assert cond.fieldref == "test"
 
 
+def test_correlation_condition_with_field_to_dict():
+    assert SigmaCorrelationCondition(
+        op=SigmaCorrelationConditionOperator.GTE,
+        count=10,
+        fieldref="test"
+    ).to_dict() == {
+        "field": "test",
+        "gte": 10
+    }
+    
+
 def test_correlation_condition_invalid_multicond():
     with pytest.raises(
         SigmaCorrelationConditionError,

--- a/tests/test_correlations.py
+++ b/tests/test_correlations.py
@@ -432,14 +432,9 @@ def test_correlation_condition_with_field():
 
 def test_correlation_condition_with_field_to_dict():
     assert SigmaCorrelationCondition(
-        op=SigmaCorrelationConditionOperator.GTE,
-        count=10,
-        fieldref="test"
-    ).to_dict() == {
-        "field": "test",
-        "gte": 10
-    }
-    
+        op=SigmaCorrelationConditionOperator.GTE, count=10, fieldref="test"
+    ).to_dict() == {"field": "test", "gte": 10}
+
 
 def test_correlation_condition_invalid_multicond():
     with pytest.raises(

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -1188,6 +1188,7 @@ def test_sigmarule_to_dict(sigma_rule: SigmaRule):
     assert sigma_rule.to_dict() == {
         "title": "Test",
         "id": "9a6cafa7-1481-4e64-89a1-1f69ed08618c",
+        "name": "test",
         "status": "test",
         "description": "This is a test",
         "references": [


### PR DESCRIPTION
## SigmaCorrelationCondition to_dict() method
The "field" field of a condition is missing in the to_dict() method of SigmaCorrelationCondition.

I found the bug when converting a value_count SigmaCorrelation rule to_dict() and then importing the created dictionary via from_dict(), resulting in a "sigma.exceptions.SigmaCorrelationRuleError: Value count correlation rule without field reference".

**Example:**

```yaml
condition:
    field: User
    gte: 99
```

`SigmaCorrelationCondition.to_dict()` results in the version with the bug in:
```json
{"gte": 99}
```

Now it is correctly:
```json
{"field": "User", "gte": 99}
```

## SigmaRuleBase to_dict() method
The rule "name" field is missing in the `to_dict()` method of SigmaRuleBase.

```python
941     # Convert to string where possible
942     for field in ("id", "status", "level", "author", "description"):
943         if (s := self.__getattribute__(field)) is not None:
944            d[field] = str(s)
```

The simple fix:
```python
941     # Convert to string where possible
942     for field in ("id", "status", "level", "author", "description", "name"):
943         if (s := self.__getattribute__(field)) is not None:
944            d[field] = str(s)
```