### PR TITLE
Add `__hash__` function to `SigmaLevel` & `SigmaStatus`

### DIFF
--- a/sigma/rule.py
+++ b/sigma/rule.py
@@ -79,6 +79,9 @@ class SigmaStatus(EnumLowercaseStringMixin, Enum):
 
         raise sigma_exceptions.SigmaTypeError("Must be a SigmaStatus", source=other)
 
+    def __hash__(self):
+        return self.value.__hash__()
+
 
 class SigmaLevel(EnumLowercaseStringMixin, Enum):
     INFORMATIONAL = auto()
@@ -122,6 +125,9 @@ class SigmaLevel(EnumLowercaseStringMixin, Enum):
             return self.value < other.value
 
         raise sigma_exceptions.SigmaTypeError("Must be a SigmaLevel", source=other)
+
+    def __hash__(self):
+        return self.value.__hash__()
 
 
 class SigmaRelatedType(EnumLowercaseStringMixin, Enum):


### PR DESCRIPTION
By implementing `__eq__` but not `__hash__`, the `SigmaLevel` enum can no longer be used as the key of a dictionary (see the second paragraph of this Python documentation (1)). The code for the ATT&CK framework integration was however using it in this way (2), and this was leading to runtime errors in `sigma-cli`. This PR adds in an implementation of `__hash__` to allow it to continue to be used as such, and similarly for `SigmaStatus`.

1. [`https://docs.python.org/3.1/reference/datamodel.html#object.__hash__`](https://docs.python.org/3.1/reference/datamodel.html#object.__hash__)
2. https://github.com/SigmaHQ/sigma-cli/blob/main/sigma/analyze/attack.py#L19