### PR TITLE
added fix to return modified date field

### DIFF
--- a/sigma/rule.py
+++ b/sigma/rule.py
@@ -1055,6 +1055,8 @@ class SigmaRuleBase:
             d["tags"] = [str(tag) for tag in self.tags]
         if self.date is not None:
             d["date"] = self.date.isoformat()
+        if self.modified is not None:
+            d["modified"] = self.modified.isoformat()
 
         # custom attributes
         d.update(self.custom_attributes)


### PR DESCRIPTION
Hi, 

I had a use case for using `to_dict()` method and check for rule modified field but noticed that this field is not returned. Added a quick fix.