### PR TITLE
feat: ✨ Load custom field in the logsource

### DIFF
--- a/sigma/rule.py
+++ b/sigma/rule.py
@@ -220,11 +220,6 @@ class SigmaLogSource:
                 "Sigma log source can't be empty", source=self.source
             )
 
-        if not self.custom_attributes is None:
-            raise sigma_exceptions.SigmaLogsourceError(
-                "Sigma log source have custom field", source=self.source
-            )
-
     @classmethod
     def from_dict(
         cls, logsource: dict, source: Optional[SigmaRuleLocation] = None

--- a/sigma/rule.py
+++ b/sigma/rule.py
@@ -211,6 +211,7 @@ class SigmaLogSource:
     product: Optional[str] = field(default=None)
     service: Optional[str] = field(default=None)
     source: Optional[SigmaRuleLocation] = field(default=None, compare=False)
+    custom_attributes: Optional[Dict[str, Any]] = field(default=None, compare=False)
 
     def __post_init__(self):
         """Ensures that log source is not empty."""
@@ -219,16 +220,25 @@ class SigmaLogSource:
                 "Sigma log source can't be empty", source=self.source
             )
 
+        if not self.custom_attributes is None:
+            raise sigma_exceptions.SigmaLogsourceError(
+                "Sigma log source have custom field", source=self.source
+            )
+
     @classmethod
     def from_dict(
         cls, logsource: dict, source: Optional[SigmaRuleLocation] = None
     ) -> "SigmaLogSource":
         """Returns SigmaLogSource object from dict with fields."""
+        custom_attributes = {
+            k: v for k, v in logsource.items() if k not in set(cls.__dataclass_fields__.keys())
+        }
         return cls(
             logsource.get("category"),
             logsource.get("product"),
             logsource.get("service"),
             source,
+            custom_attributes if len(custom_attributes) > 0 else None,
         )
 
     def to_dict(self) -> dict:

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -1490,37 +1490,3 @@ def test_sigma_rule_conversion_result_no_result(sigma_rule):
 def test_sigma_rule_disable_output(sigma_rule):
     sigma_rule.disable_output()
     assert sigma_rule._output == False
-
-
-def test_sigmarule_fromyaml_with_custom_logsource_attribute():
-    with pytest.raises(
-        sigma_exceptions.SigmaLogsourceError, match="Sigma log source have custom field"
-    ):
-        sigmarule_from_yaml = SigmaRule.from_yaml(
-            """
-        title: Test
-        id: 9a6cafa7-1481-4e64-89a1-1f69ed08618c
-        name: test
-        taxonomy: test
-        status: test
-        description: This is a test
-        references:
-            - ref1
-            - ref2
-        tags:
-            - attack.execution
-            - attack.t1059
-        author: Thomas Patzke
-        date: 2020/07/12
-        logsource:
-            categorie: process_creation
-            product: windows
-        detection:
-            selection:
-                CommandLine|contains: test.exe
-            condition: selection
-        falsepositives:
-            - Everything
-        level: low
-        """
-        )

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -1490,3 +1490,37 @@ def test_sigma_rule_conversion_result_no_result(sigma_rule):
 def test_sigma_rule_disable_output(sigma_rule):
     sigma_rule.disable_output()
     assert sigma_rule._output == False
+
+
+def test_sigmarule_fromyaml_with_custom_logsource_attribute():
+    with pytest.raises(
+        sigma_exceptions.SigmaLogsourceError, match="Sigma log source have custom field"
+    ):
+        sigmarule_from_yaml = SigmaRule.from_yaml(
+            """
+        title: Test
+        id: 9a6cafa7-1481-4e64-89a1-1f69ed08618c
+        name: test
+        taxonomy: test
+        status: test
+        description: This is a test
+        references:
+            - ref1
+            - ref2
+        tags:
+            - attack.execution
+            - attack.t1059
+        author: Thomas Patzke
+        date: 2020/07/12
+        logsource:
+            categorie: process_creation
+            product: windows
+        detection:
+            selection:
+                CommandLine|contains: test.exe
+            condition: selection
+        falsepositives:
+            - Everything
+        level: low
+        """
+        )


### PR DESCRIPTION
In the current version custom field are ignored in the logsource section.
The side effect is you can not detect typo error and the rule will be loaded.
Like in my test `categorie: process_creation` will give a valid `category: None`

I have add a SigmaLogsourceError and a optionnal `custom_attributes`
