### PR TITLE
Remove useless sigmahq validator

### DIFF
--- a/sigma/validators/core/metadata.py
+++ b/sigma/validators/core/metadata.py
@@ -67,22 +67,6 @@ class IdentifierUniquenessValidator(SigmaRuleValidator):
 
 
 @dataclass
-class TitleLengthSigmaHQIssue(SigmaValidationIssue):
-    description = "Rule has a title longer than 110 characters"
-    severity = SigmaValidationIssueSeverity.MEDIUM
-
-
-class TitleLengthSigmaHQValidator(SigmaRuleValidator):
-    """Checks if rule has a title length longer than 110."""
-
-    def validate(self, rule: SigmaRule) -> List[TitleLengthSigmaHQIssue]:
-        if len(rule.title) > 110:
-            return [TitleLengthSigmaHQIssue([rule])]
-        else:
-            return []
-
-
-@dataclass
 class DuplicateTitleIssue(SigmaValidationIssue):
     description: ClassVar[str] = "Rule title used by multiple rules"
     severity: ClassVar[SigmaValidationIssueSeverity] = SigmaValidationIssueSeverity.HIGH
@@ -206,25 +190,6 @@ class DuplicateFilenameValidator(SigmaRuleValidator):
             for filename, paths in self.filenames_to_paths.items()
             if len(paths) > 1
         ]
-
-
-@dataclass
-class FilenameSigmahqIssue(SigmaValidationIssue):
-    description: ClassVar[str] = "Rule filemane doesn't match SigmaHQ standard"
-    severity: ClassVar[SigmaValidationIssueSeverity] = SigmaValidationIssueSeverity.HIGH
-    filename: str
-
-
-class FilenameSigmahqValidator(SigmaRuleValidator):
-    """Check rule filename match SigmaHQ standard."""
-
-    def validate(self, rule: SigmaRule) -> List[SigmaValidationIssue]:
-        filename_pattern = re.compile(r"[a-z0-9_]{10,90}\.yml")
-        if rule.source is not None:
-            filename = rule.source.path.name
-            if filename_pattern.match(filename) is None or not "_" in filename:
-                return [FilenameSigmahqIssue(rule, filename)]
-        return []
 
 
 @dataclass

--- a/tests/test_validators_metadata.py
+++ b/tests/test_validators_metadata.py
@@ -11,8 +11,6 @@ from sigma.validators.core.metadata import (
     IdentifierExistenceIssue,
     IdentifierUniquenessValidator,
     IdentifierCollisionIssue,
-    TitleLengthSigmaHQIssue,
-    TitleLengthSigmaHQValidator,
     DuplicateTitleIssue,
     DuplicateTitleValidator,
     DuplicateReferencesIssue,
@@ -25,8 +23,6 @@ from sigma.validators.core.metadata import (
     DateExistenceIssue,
     DuplicateFilenameValidator,
     DuplicateFilenameIssue,
-    FilenameSigmahqValidator,
-    FilenameSigmahqIssue,
     FilenameLenghValidator,
     FilenameLenghIssue,
     CustomAttributesValidator,
@@ -115,40 +111,6 @@ def test_validator_identifier_uniqueness(rules_with_id_collision):
             rules_with_id_collision, UUID("32532a0b-e56c-47c9-bcbb-3d88bd670c37")
         )
     ]
-
-
-def test_validator_lengthy_title():
-    validator = TitleLengthSigmaHQValidator()
-    rule = SigmaRule.from_yaml(
-        """
-    title: ThisIsAVeryLongTitleThisIsAVeryLongTitleThisIsAVeryLongTitleThisIsAVeryLongTitleThisIsAVeryLongTitleThisIsAVery
-    status: test
-    logsource:
-        category: test
-    detection:
-        sel:
-            field: path\\*something
-        condition: sel
-    """
-    )
-    assert validator.validate(rule) == [TitleLengthSigmaHQIssue([rule])]
-
-
-def test_validator_lengthy_title_valid():
-    validator = TitleLengthSigmaHQValidator()
-    rule = SigmaRule.from_yaml(
-        """
-    title: Test
-    status: test
-    logsource:
-        category: test
-    detection:
-        sel:
-            field: path\\*something
-        condition: sel
-    """
-    )
-    assert validator.validate(rule) == []
 
 
 def test_validator_duplicate_title():
@@ -360,20 +322,6 @@ def test_validator_duplicate_filename_multiple_rules_in_one_file():
     assert validator.validate(rule1) == []
     assert validator.validate(rule2) == []
     assert validator.finalize() == []
-
-
-def test_validator_sigmahqfilename():
-    validator = FilenameSigmahqValidator()
-    sigma_collection = SigmaCollection.load_ruleset(["tests/files/rule_filename_errors"])
-    rule = sigma_collection[0]
-    assert validator.validate(rule) == [FilenameSigmahqIssue([rule], "Name.yml")]
-
-
-def test_validator_sigmahqfilename_valid():
-    validator = FilenameSigmahqValidator()
-    sigma_collection = SigmaCollection.load_ruleset(["tests/files/rule_valid"])
-    rule = sigma_collection[0]
-    assert validator.validate(rule) == []
 
 
 def test_validator_filename_lengh():


### PR DESCRIPTION
chore: Remove sigmahq validator as there are now in the pySigma-validators-sigmaHQ.
