### PR TITLE
Fix bug when applying a filter to multiple rules

### DIFF
--- a/sigma/filters.py
+++ b/sigma/filters.py
@@ -188,19 +188,20 @@ class SigmaFilter(SigmaRuleBase):
         if not self._should_apply_on_rule(rule):
             return rule
 
+        filter_condition = self.filter.condition[0]
         for original_cond_name, condition in self.filter.detections.items():
             cond_name = "_filt_" + ("".join(random.choices(string.ascii_lowercase, k=10)))
 
             # Replace each instance of the original condition name with the new condition name to avoid conflicts
-            self.filter.condition[0] = re.sub(
+            filter_condition = re.sub(
                 rf"[^ ]*{original_cond_name}[^ ]*",
                 cond_name,
-                self.filter.condition[0],
+                filter_condition,
             )
             rule.detection.detections[cond_name] = condition
 
         for i, condition in enumerate(rule.detection.condition):
-            rule.detection.condition[i] = f"({condition}) and " + f"({self.filter.condition[0]})"
+            rule.detection.condition[i] = f"({condition}) and " + f"({filter_condition})"
 
         # Reparse the rule to update the parsed conditions
         rule.detection.__post_init__()

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,3 +1,5 @@
+import copy
+import uuid
 from pathlib import Path
 from typing import Callable
 
@@ -131,6 +133,19 @@ def test_basic_filter_application_against_correlation_rule(
         "TargetDomainName, mappedB\n"
         "| where event_count >= 10"
     ]
+
+
+def test_filter_application_to_several_rules(sigma_filter, test_backend, rule_collection):
+    rule_copy = copy.deepcopy(rule_collection.rules[0])
+    rule_copy.id = uuid.UUID("257f7780-ea6c-48d4-ae8e-2b95b3740d84")
+    sigma_filter.filter.rules.append(SigmaRuleReference(str(rule_copy.id)))
+
+    rule_collection.rules.extend([rule_copy, sigma_filter])
+
+    assert (
+        test_backend.convert(rule_collection)
+        == ['(EventID=4625 or EventID2=4624) and not User startswith "adm_"'] * 2
+    )
 
 
 def test_reducing_rule_collections(sigma_filter, test_backend, rule_collection):


### PR DESCRIPTION
Only modify a copy of `self.filter.condition[0]` so that the filter can be applied to multiple rules.

Fixes #231