### PR TITLE
Resolve directory for pipelines

### DIFF
--- a/print-coverage.py
+++ b/print-coverage.py
@@ -13,4 +13,3 @@ elif coverage >= 85.0:
     print("COVERAGE_COLOR=orange")
 else:
     print("COVERAGE_COLOR=red")
-

--- a/print-coverage.py
+++ b/print-coverage.py
@@ -13,3 +13,4 @@ elif coverage >= 85.0:
     print("COVERAGE_COLOR=orange")
 else:
     print("COVERAGE_COLOR=red")
+

--- a/sigma/processing/resolver.py
+++ b/sigma/processing/resolver.py
@@ -1,6 +1,5 @@
-import glob
-import os.path
 from dataclasses import dataclass, field
+from pathlib import Path
 from sigma.exceptions import (
     SigmaPipelineNotAllowedForBackendError,
     SigmaPipelineNotFoundError,
@@ -82,9 +81,10 @@ class ProcessingPipelineResolver:
         """
         pipelines = []
         for spec in pipeline_specs:
-            if os.path.isdir(spec):
-                for path in glob.glob("**.yml", root_dir=spec):
-                    pipelines.append(self.resolve_pipeline(f"{spec}/{path}", target))
+            spec_path = Path(spec)
+            if spec_path.is_dir():
+                for path in spec_path.glob("**/*.yml"):
+                    pipelines.append(self.resolve_pipeline(str(path), target))
             else:
                 pipelines.append(self.resolve_pipeline(spec, target))
         return (

--- a/tests/files/pipelines/pipeline-1.yml
+++ b/tests/files/pipelines/pipeline-1.yml
@@ -1,0 +1,6 @@
+name: Test 1
+priority: 10
+transformations:
+  - id: test-1
+    type: field_name_suffix
+    suffix: .test

--- a/tests/files/pipelines/pipeline-2.yml
+++ b/tests/files/pipelines/pipeline-2.yml
@@ -1,5 +1,5 @@
 name: Test 2
-priority: 10
+priority: 20
 transformations:
   - id: test-2
     type: field_name_prefix

--- a/tests/files/pipelines/pipeline-2.yml
+++ b/tests/files/pipelines/pipeline-2.yml
@@ -1,0 +1,6 @@
+name: Test 2
+priority: 10
+transformations:
+  - id: test-2
+    type: field_name_prefix
+    prefix: test.

--- a/tests/test_processing_resolver.py
+++ b/tests/test_processing_resolver.py
@@ -5,7 +5,10 @@ from sigma.exceptions import (
 )
 from sigma.processing.resolver import ProcessingPipelineResolver
 from sigma.processing.pipeline import ProcessingPipeline, ProcessingItem
-from sigma.processing.transformations import AddFieldnameSuffixTransformation
+from sigma.processing.transformations import (
+    AddFieldnamePrefixTransformation,
+    AddFieldnameSuffixTransformation,
+)
 from collections.abc import Iterable
 
 
@@ -55,6 +58,21 @@ def test_resolve_file(processing_pipeline_resolver: ProcessingPipelineResolver):
         ],
         name="Test",
         priority=10,
+    )
+
+
+def test_resolve_directory(processing_pipeline_resolver):
+    assert processing_pipeline_resolver.resolve(["tests/files/pipelines"]) == ProcessingPipeline(
+        items=[
+            ProcessingItem(
+                AddFieldnameSuffixTransformation(".test"),
+                identifier="test-1",
+            ),
+            ProcessingItem(
+                AddFieldnamePrefixTransformation("test."),
+                identifier="test-2",
+            ),
+        ],
     )
 
 


### PR DESCRIPTION
Add the ability to resolve processing pipelines by directory.

Related to https://github.com/SigmaHQ/sigma-cli/issues/42
When this is merged and a new version of pysigma is released, I will open a PR for sigma-cli.