### PR TITLE
Fix type hints for conversion base

### DIFF
--- a/sigma/conversion/base.py
+++ b/sigma/conversion/base.py
@@ -24,7 +24,7 @@ from sigma.exceptions import (
     SigmaValueError,
 )
 from sigma.conversion.deferred import DeferredQueryExpression
-from typing import Pattern, Union, ClassVar, Optional, Tuple, List, Dict, Any
+from typing import Pattern, Union, ClassVar, Optional, Tuple, List, Dict, Any, Type
 from sigma.processing.pipeline import ProcessingPipeline
 from sigma.collection import SigmaCollection
 from sigma.rule import SigmaRule
@@ -694,7 +694,7 @@ class TextQueryBackend(Backend):
 
     # Operator precedence: tuple of Condition{AND,OR,NOT} in order of precedence.
     # The backend generates grouping if required
-    precedence: ClassVar[Tuple[type[ConditionItem], type[ConditionItem], type[ConditionItem]]] = (
+    precedence: ClassVar[Tuple[Type[ConditionItem], Type[ConditionItem], Type[ConditionItem]]] = (
         ConditionNOT,
         ConditionAND,
         ConditionOR,

--- a/sigma/conversion/base.py
+++ b/sigma/conversion/base.py
@@ -694,7 +694,7 @@ class TextQueryBackend(Backend):
 
     # Operator precedence: tuple of Condition{AND,OR,NOT} in order of precedence.
     # The backend generates grouping if required
-    precedence: ClassVar[Tuple[ConditionItem, ConditionItem, ConditionItem]] = (
+    precedence: ClassVar[Tuple[type[ConditionItem], type[ConditionItem], type[ConditionItem]]] = (
         ConditionNOT,
         ConditionAND,
         ConditionOR,


### PR DESCRIPTION
The types hints for the `precedence` property in the `sigma.conversion.base.py` don't match the default value. This PR fixes that.