### PR TITLE
Include netwitness backend in the related projects section

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ query languages and log data models is provided by additional packages that exte
 * [pySigma-backend-splunk](https://github.com/SigmaHQ/pySigma-backend-splunk)
 * [pySigma-pipeline-sysmon](https://github.com/SigmaHQ/pySigma-pipeline-sysmon)
 * [pySigma-pipeline-crowdstrike](https://github.com/SigmaHQ/pySigma-pipeline-crowdstrike)
+* [pySigma-backend-netwitness](https://github.com/marcelkwaschny/pySigma-backend-netwitness)
 
 All packages can also be installed from PyPI if not mentioned otherwise by the Python package
 manager of your choice.


### PR DESCRIPTION
We created a backend for netwitness and would be very happy if it's included in the related projects section of pySigma 😁 !