### PR TITLE
Allow SigmaRuleTag objects to be compared with their string represent…

### DIFF
--- a/sigma/rule.py
+++ b/sigma/rule.py
@@ -204,6 +204,11 @@ class SigmaRuleTag:
     def __str__(self) -> str:
         return f"{self.namespace}.{self.name}"
 
+    def __eq__(self, other) -> bool:
+        if isinstance(other, str):
+            return other == f"{self.namespace}.{self.name}"
+        return super().__eq__(other)
+
 
 @dataclass(frozen=True)
 class SigmaLogSource:

--- a/sigma/rule.py
+++ b/sigma/rule.py
@@ -206,8 +206,9 @@ class SigmaRuleTag:
 
     def __eq__(self, other) -> bool:
         if isinstance(other, str):
-            return other == f"{self.namespace}.{self.name}"
-        return super().__eq__(other)
+            return other == self.__str__()
+        elif type(self) is type(other):
+            return self.name == other.name and self.namespace == other.namespace
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Allow SigmaRuleTag objects to be compared with their string representation (namespace.name)

This allows for stuff like 

```python
if "attack.discovery" in rule.tags:
  do_something()
```

Which is much more user-friendly than doing a for-loop to do such comparisons :) 