### PR TITLE
Fixes #241 - Pipeline Resolving Issue

### DIFF
--- a/sigma/conditions.py
+++ b/sigma/conditions.py
@@ -265,7 +265,7 @@ class SigmaCondition(ProcessingItemTrackingMixin):
         """
         if "|" in self.condition:
             raise SigmaConditionError(
-                "The pipe syntax in Sigma conditions will be deprecated and replaced by Sigma correlations. pySigma doesn't supports this syntax."
+                "The pipe syntax in Sigma conditions has been deprecated and replaced by Sigma correlations. pySigma doesn't supports this syntax."
             )
         try:
             parsed = condition.parseString(self.condition, parse_all=True)[0]

--- a/sigma/conversion/base.py
+++ b/sigma/conversion/base.py
@@ -82,7 +82,7 @@ class Backend(ABC):
       passes the generated queries.
     * finalize_output_<format> finalizes the conversion result of a whole rule set in the specified format.
       By default finalize_output_default is called and outputs a list of all queries. Further formats can be
-      implemented in similar methods. The defaulf format can be specified in the class variable default_format.
+      implemented in similar methods. The default format can be specified in the class variable default_format.
 
     Implementation of a backend:
 
@@ -90,7 +90,7 @@ class Backend(ABC):
        or the final query representation.
     2. If required, implement a per-query finalization step in finalize_query. Each Sigma rule condition
        results in a query. This can embed the generated query into other structures (e.g. boilerplate code,
-       prefix/postifx query parts) or convert the intermediate into a final query representation.
+       prefix/postfix query parts) or convert the intermediate into a final query representation.
     3. If required, implement a finalization step working on all generated queries in finalize. This can
        embed the queries into other data structures (e.g. JSON or XML containers for import into the target
        system) or perform the conversion of an intermediate to the final query representation.

--- a/sigma/exceptions.py
+++ b/sigma/exceptions.py
@@ -247,6 +247,12 @@ class SigmaFeatureNotSupportedByBackendError(SigmaError):
     pass
 
 
+class SigmaPipelineParsingError(SigmaError):
+    """Error in parsing of a Sigma processing pipeline"""
+
+    pass
+
+
 class SigmaPipelineNotFoundError(SigmaError, ValueError):
     """An attempt to resolve a processing pipeline from a specifier failed because it was not
     found."""

--- a/sigma/processing/pipeline.py
+++ b/sigma/processing/pipeline.py
@@ -31,7 +31,7 @@ from sigma.processing.conditions import (
     field_name_conditions,
     FieldNameProcessingCondition,
 )
-from sigma.exceptions import SigmaConfigurationError, SigmaTypeError
+from sigma.exceptions import SigmaConfigurationError, SigmaTypeError, SigmaPipelineParsingError
 import yaml
 
 from sigma.types import SigmaFieldReference, SigmaType
@@ -500,7 +500,10 @@ class ProcessingPipeline:
     @classmethod
     def from_yaml(cls, processing_pipeline: str) -> "ProcessingPipeline":
         """Convert YAML input string into processing pipeline."""
-        parsed_pipeline = yaml.safe_load(processing_pipeline)
+        try:
+            parsed_pipeline = yaml.safe_load(processing_pipeline)
+        except yaml.parser.ParserError as e:
+            raise SigmaPipelineParsingError(f"Error in parsing of a Sigma processing pipeline")
         return cls.from_dict(parsed_pipeline)
 
     def apply(

--- a/sigma/processing/resolver.py
+++ b/sigma/processing/resolver.py
@@ -81,7 +81,7 @@ class ProcessingPipelineResolver:
         """
         pipelines = []
         for spec in pipeline_specs:
-            spec_path = Path(spec.rstrip("*"))
+            spec_path = Path(spec.rstrip("/*"))
             if spec_path.is_dir():
                 for path in spec_path.glob("**/*.yml"):
                     pipelines.append(self.resolve_pipeline(str(path), target))

--- a/sigma/processing/resolver.py
+++ b/sigma/processing/resolver.py
@@ -81,7 +81,7 @@ class ProcessingPipelineResolver:
         """
         pipelines = []
         for spec in pipeline_specs:
-            spec_path = Path(spec)
+            spec_path = Path(spec.rstrip("*"))
             if spec_path.is_dir():
                 for path in spec_path.glob("**/*.yml"):
                     pipelines.append(self.resolve_pipeline(str(path), target))


### PR DESCRIPTION
This PR aims to resolve the issue raised by #241

The `resolve` function contains a bug that arise when a user provides a pipeline folder ending with a wildcard via sigma-cli.

Example
```bash
sigma convert -t splunk -p /pipelines/* sigma_rule.yml
```
The `/pipelines/*` will be passed to the resolve function and converted into a path and then a check if its a directory is made.

```python
for spec in pipeline_specs:
            spec_path = Path(spec)
            if spec_path.is_dir():
                for path in spec_path.glob("**/*.yml"):
                    pipelines.append(self.resolve_pipeline(str(path), target))
            else:
                pipelines.append(self.resolve_pipeline(spec, target))
```

The issue here is that `is_dir` will return false if the string is appended with a wildcard. (see below)

```python
>>> Path("pipelines/*").is_dir()
False
>>> Path("pipelines/").is_dir()
True
```

Since its not considered a directory, it'll enter the else and treats them as filename and parses them with `from_yaml` which can eventually fails depending on the contents present in the folder.

This PR resolve this by introducing the following

- Adds an `rstrip` to remove ending wildcards in paths
- Adds an exception handling for the `from_yaml` in case of incorrect yaml parsing.