### PR TITLE
add new validator - DanglingCondition

### DIFF
--- a/sigma/validators/core/condition.py
+++ b/sigma/validators/core/condition.py
@@ -28,7 +28,7 @@ class DanglingDetectionValidator(SigmaRuleValidator):
         self, cond: ConditionItem, detections: SigmaDetections
     ) -> Set[str]:
         """
-        Return detection item identifierd referenced by condition.
+        Return detection item identifier referenced by condition.
 
         :param cond: Condition to analyze.
         :type cond: ConditionItem
@@ -65,13 +65,70 @@ class DanglingDetectionValidator(SigmaRuleValidator):
 
 
 @dataclass
+class DanglingConditionIssue(SigmaValidationIssue):
+    description: ClassVar[str] = (
+        "Rule defines a condition that contains references to unknown detection definitions"
+    )
+    severity: ClassVar[SigmaValidationIssueSeverity] = SigmaValidationIssueSeverity.HIGH
+    condition_name: str
+
+
+class DanglingConditionValidator(SigmaRuleValidator):
+    """Check for non existing detection definitions referenced from the condition."""
+
+    def condition_unknown_referenced_ids(
+        self, cond: ConditionItem, detections: SigmaDetections
+    ) -> Set[str]:
+        """
+        Return set of unknown item identifier referenced by condition.
+
+        :param cond: Condition to analyze.
+        :type cond: ConditionItem
+        :param detections: Detections referenced from condition.
+        :type detections: SigmaDetections
+        :return: Set of unknown referenced detection identifiers.
+        :rtype: Set[str]
+        """
+        if isinstance(cond, ConditionSelector):  # Resolve all referenced ids and return
+            resolved_detections = {
+                cond.identifier for cond in cond.resolve_referenced_detections(detections)
+            }
+            if (
+                resolved_detections == set()
+            ):  # If the function returns an empty set, it means that there was no corresponding detection identifier for the condition identifier.
+                return {cond.pattern}
+            else:
+                return {}
+        elif isinstance(cond, ConditionItem):  # Traverse into subconditions
+            ids = set()
+            for arg in cond.args:
+                ids.update(self.condition_unknown_referenced_ids(arg, detections))
+            return ids
+        else:  # Fallback if something different is encountered: return empty set.
+            return set()
+
+    def validate(self, rule: SigmaRule) -> List[SigmaValidationIssue]:
+        if isinstance(rule, SigmaCorrelationRule):
+            return []  # Correlation rules do not have detections
+
+        unknown_detection_refs = set()
+        for condition in rule.detection.parsed_condition:
+            parsed_condition = condition.parse(False)
+            unknown_detection_refs.update(
+                self.condition_unknown_referenced_ids(parsed_condition, rule.detection)
+            )
+
+        return [DanglingConditionIssue([rule], name) for name in unknown_detection_refs]
+
+
+@dataclass
 class ThemConditionWithSingleDetectionIssue(SigmaValidationIssue):
     description: ClassVar[str] = "Rule refers to 'them' but has only one condition"
     severity: ClassVar[SigmaValidationIssueSeverity] = SigmaValidationIssueSeverity.LOW
 
 
 class ThemConditionWithSingleDetectionValidator(SigmaRuleValidator):
-    """Detect conditions refering to 'them' with only one detection."""
+    """Detect conditions referring to 'them' with only one detection."""
 
     def validate(self, rule: SigmaRule) -> List[SigmaValidationIssue]:
         if isinstance(rule, SigmaCorrelationRule):

--- a/sigma/validators/core/condition.py
+++ b/sigma/validators/core/condition.py
@@ -67,7 +67,7 @@ class DanglingDetectionValidator(SigmaRuleValidator):
 @dataclass
 class DanglingConditionIssue(SigmaValidationIssue):
     description: ClassVar[str] = (
-        "Rule defines a condition that contains references to unknown detection definitions"
+        "Rule defines a condition that contains references to an unknown detection definition"
     )
     severity: ClassVar[SigmaValidationIssueSeverity] = SigmaValidationIssueSeverity.HIGH
     condition_name: str

--- a/tests/test_validators_condition.py
+++ b/tests/test_validators_condition.py
@@ -4,11 +4,34 @@ from sigma.validators.core.condition import (
     AllOfThemConditionIssue,
     AllOfThemConditionValidator,
     DanglingDetectionIssue,
+    DanglingConditionIssue,
     DanglingDetectionValidator,
+    DanglingConditionValidator,
     ThemConditionWithSingleDetectionIssue,
     ThemConditionWithSingleDetectionValidator,
 )
 from .test_correlations import correlation_rule
+
+
+def test_validator_dangling_condition():
+    validator = DanglingConditionValidator()
+    rule = SigmaRule.from_yaml(
+        """
+    title: Test
+    status: test
+    logsource:
+        category: test
+    detection:
+        referenced1:
+            field1: val1
+        referenced2:
+            field2: val2
+        referenced3:
+            field3: val3
+        condition: (referenced1 or referenced2) and referenced3 and referenced4
+    """
+    )
+    assert validator.validate(rule) == [DanglingConditionIssue([rule], "referenced4")]
 
 
 def test_validator_dangling_detection():
@@ -60,6 +83,27 @@ def test_validator_dangling_detection_valid():
     assert validator.validate(rule) == []
 
 
+def test_validator_dangling_condition_valid():
+    validator = DanglingConditionValidator()
+    rule = SigmaRule.from_yaml(
+        """
+    title: Test
+    status: test
+    logsource:
+        category: test
+    detection:
+        referenced1:
+            field1: val1
+        referenced2:
+            field2: val2
+        referenced3:
+            field3: val3
+        condition: (referenced1 or referenced2) and referenced3
+    """
+    )
+    assert validator.validate(rule) == []
+
+
 def test_validator_dangling_detection_valid_x_of_wildcard():
     validator = DanglingDetectionValidator()
     rule = SigmaRule.from_yaml(
@@ -81,8 +125,50 @@ def test_validator_dangling_detection_valid_x_of_wildcard():
     assert validator.validate(rule) == []
 
 
+def test_validator_dangling_condition_valid_x_of_wildcard():
+    validator = DanglingConditionValidator()
+    rule = SigmaRule.from_yaml(
+        """
+    title: Test
+    status: test
+    logsource:
+        category: test
+    detection:
+        referenced1:
+            field1: val1
+        referenced2:
+            field2: val2
+        referenced3:
+            field3: val3
+        condition: 1 of referenced*
+    """
+    )
+    assert validator.validate(rule) == []
+
+
 def test_validator_dangling_detection_valid_x_of_them():
     validator = DanglingDetectionValidator()
+    rule = SigmaRule.from_yaml(
+        """
+    title: Test
+    status: test
+    logsource:
+        category: test
+    detection:
+        referenced1:
+            field1: val1
+        referenced2:
+            field2: val2
+        referenced3:
+            field3: val3
+        condition: 1 of them
+    """
+    )
+    assert validator.validate(rule) == []
+
+
+def test_validator_dangling_condition_valid_x_of_them():
+    validator = DanglingConditionValidator()
     rule = SigmaRule.from_yaml(
         """
     title: Test

--- a/tests/test_validators_condition.py
+++ b/tests/test_validators_condition.py
@@ -22,16 +22,16 @@ def test_validator_dangling_condition():
     logsource:
         category: test
     detection:
-        referenced1:
+        selection:
             field1: val1
-        referenced2:
+        filter_main_1:
+            field1: val1
+        filter_main_optional_1:
             field2: val2
-        referenced3:
-            field3: val3
-        condition: (referenced1 or referenced2) and referenced3 and referenced4
+        condition: selection and not 1 of filter_main_* and not 1 of filter_optional_*
     """
     )
-    assert validator.validate(rule) == [DanglingConditionIssue([rule], "referenced4")]
+    assert validator.validate(rule) == [DanglingConditionIssue([rule], "filter_optional_*")]
 
 
 def test_validator_dangling_detection():


### PR DESCRIPTION
## Description

This PR adds a new validator - `DanglingCondition`

### Motivation

In certain edge cases, a sigma rule author might reference an unknown detection definition from the condition in the form of `1 of something`.  Example:

```yml
title: Test
status: test
logsource:
    category: test
detection:
    selection:
        field1: val1
    filter_main_1:
        field1: val1
    filter_main_optional_1:
        field2: val2
    condition: selection and not 1 of filter_main_* and not 1 of filter_optional_*
```

Currently pySigma gracefully handles the conversion without error but this might lead to confusion in certain tools and the semantically the rule contain an "error".

### Solution 

This PR adds a new validator that is very similar to the DanglingDetection. The difference being the use of the fact that when a ConditionSelector calls `resolve_referenced_detections` it will return an empty set if the detection definition doesn't exist (i.e match any patterns).