### PR TITLE
Add `set_custom_attribute` transformation and tests

### DIFF
--- a/sigma/processing/transformations.py
+++ b/sigma/processing/transformations.py
@@ -964,6 +964,24 @@ class DetectionItemFailureTransformation(DetectionItemTransformation):
         raise SigmaTransformationError(self.message)
 
 
+@dataclass
+class SetCustomAttributeTransformation(Transformation):
+    """
+    Sets an arbitrary custom attribute on a rule, that can be used by a backend during processing.
+    """
+
+    attribute: str
+    value: Any
+
+    def apply(
+        self,
+        pipeline: "sigma.processing.pipeline.ProcessingPipeline",
+        rule: Union[SigmaRule, SigmaCorrelationRule],
+    ) -> None:
+        super().apply(pipeline, rule)
+        rule.custom_attributes[self.attribute] = self.value
+
+
 transformations: Dict[str, Transformation] = {
     "field_name_mapping": FieldMappingTransformation,
     "field_name_prefix_mapping": FieldPrefixMappingTransformation,
@@ -987,4 +1005,5 @@ transformations: Dict[str, Transformation] = {
     "convert_type": ConvertTypeTransformation,
     "rule_failure": RuleFailureTransformation,
     "detection_item_failure": DetectionItemFailureTransformation,
+    "set_custom_attribute": SetCustomAttributeTransformation,
 }

--- a/tests/test_processing_transformations.py
+++ b/tests/test_processing_transformations.py
@@ -16,6 +16,7 @@ from sigma.processing.transformations import (
     AddFieldTransformation,
     ConvertTypeTransformation,
     RemoveFieldTransformation,
+    SetCustomAttributeTransformation,
     SetFieldTransformation,
     SetValueTransformation,
     transformations,
@@ -1565,6 +1566,26 @@ def test_detection_item_failure_transformation(dummy_pipeline, sigma_rule):
     transformation = DetectionItemFailureTransformation("Test")
     with pytest.raises(SigmaTransformationError, match="^Test$"):
         transformation.apply(dummy_pipeline, sigma_rule)
+
+
+def test_set_custom_attribute(dummy_pipeline, sigma_rule):
+    transformation = SetCustomAttributeTransformation("custom_key", "custom_value")
+    transformation.set_processing_item(ProcessingItem(transformation, identifier="test"))
+
+    transformation.apply(dummy_pipeline, sigma_rule)
+    assert "custom_key" in sigma_rule.custom_attributes
+    assert sigma_rule.custom_attributes["custom_key"] == "custom_value"
+    assert sigma_rule.was_processed_by("test")
+
+
+def test_set_custom_attribute_correlation_rule(dummy_pipeline, sigma_correlation_rule):
+    transformation = SetCustomAttributeTransformation("custom_key", "custom_value")
+    transformation.set_processing_item(ProcessingItem(transformation, identifier="test"))
+
+    transformation.apply(dummy_pipeline, sigma_correlation_rule)
+    assert "custom_key" in sigma_correlation_rule.custom_attributes
+    assert sigma_correlation_rule.custom_attributes["custom_key"] == "custom_value"
+    assert sigma_correlation_rule.was_processed_by("test")
 
 
 def test_transformation_identifier_completeness():


### PR DESCRIPTION
As [suggested in the SigmaHQ Discord](https://discord.com/channels/1176230866515669072/1273146311436402761), porting the `set_custom_attribute` pipeline transformation from grafana/pySigma-backend-loki into SigmaHQ/pySigma.