### PR TITLE
Taking into account Specification V2

### DIFF
--- a/sigma/exceptions.py
+++ b/sigma/exceptions.py
@@ -151,6 +151,18 @@ class SigmaLevelError(SigmaError):
     pass
 
 
+class SigmaLicenseError(SigmaError):
+    """Error in Sigma rule license"""
+
+    pass
+
+
+class SigmaScopeError(SigmaError):
+    """Error in Sigma rule scope"""
+
+    pass
+
+
 class SigmaModifierError(SigmaError):
     """Error in Sigma rule value modifier"""
 

--- a/sigma/validators/core/tags.py
+++ b/sigma/validators/core/tags.py
@@ -23,6 +23,24 @@ import re
 
 
 @dataclass
+class InvalidTagFormatIssue(SigmaValidationIssue):
+    description: ClassVar[str] = "Invalid char in namaspace or name tag"
+    severity: ClassVar[SigmaValidationIssueSeverity] = SigmaValidationIssueSeverity.MEDIUM
+    tag: SigmaRuleTag
+
+
+class TagFormatValidator(SigmaTagValidator):
+    """Validate rule tag namespace and name allowed char"""
+
+    def validate_tag(self, tag: SigmaRuleTag) -> List[SigmaValidationIssue]:
+        tags_pattern = re.compile(r"^[a-z0-9\-\_]+\.[a-z0-9\-\_]+$")
+
+        if tags_pattern.match(str(tag)) is None:
+            return [InvalidTagFormatIssue([self.rule], tag)]
+        return []
+
+
+@dataclass
 class InvalidATTACKTagIssue(SigmaValidationIssue):
     description: ClassVar[str] = "Invalid MITRE ATT&CK tagging"
     severity: ClassVar[SigmaValidationIssueSeverity] = SigmaValidationIssueSeverity.MEDIUM

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -169,6 +169,13 @@ def test_sigmalogsource_fromdict_service_not_str():
         SigmaLogSource.from_dict({"category": "category-id", "service": ["1", "2", "3"]})
 
 
+def test_sigmalogsource_fromdict_definition_not_str():
+    with pytest.raises(sigma_exceptions.SigmaLogsourceError):
+        SigmaLogSource.from_dict(
+            {"category": "category-id", "definition": ["sysmon", "edr", "siem"]}
+        )
+
+
 def test_sigmalogsource_empty():
     with pytest.raises(sigma_exceptions.SigmaLogsourceError, match="can't be empty.*test.yml"):
         SigmaLogSource(None, None, None, source=sigma_exceptions.SigmaRuleLocation("test.yml"))
@@ -811,31 +818,38 @@ def test_sigmadetection_dict_and_keyword_to_plain():
 def test_sigmarule_fields_not_list():
     with pytest.raises(sigma_exceptions.SigmaFieldsError, match="must be a list.*test.yml"):
         SigmaRule.from_dict(
-            {"fields": "test"}, source=sigma_exceptions.SigmaRuleLocation("test.yml")
+            {"title": "test", "fields": "test"},
+            source=sigma_exceptions.SigmaRuleLocation("test.yml"),
         )
 
 
 def test_sigmarule_bad_uuid():
     with pytest.raises(sigma_exceptions.SigmaIdentifierError, match="must be an UUID.*test.yml"):
         SigmaRule.from_dict(
-            {"id": "no-uuid"}, source=sigma_exceptions.SigmaRuleLocation("test.yml")
+            {"title": "test", "id": "no-uuid"},
+            source=sigma_exceptions.SigmaRuleLocation("test.yml"),
         )
 
 
 def test_sigmarule_bad_name():
     with pytest.raises(sigma_exceptions.SigmaTypeError, match="must be a string.*test.yml"):
-        SigmaRule.from_dict({"name": 123}, source=sigma_exceptions.SigmaRuleLocation("test.yml"))
+        SigmaRule.from_dict(
+            {"title": "test", "name": 123}, source=sigma_exceptions.SigmaRuleLocation("test.yml")
+        )
 
 
 def test_sigmarule_empty_name():
     with pytest.raises(sigma_exceptions.SigmaNameError, match="must not be empty.*test.yml"):
-        SigmaRule.from_dict({"name": ""}, source=sigma_exceptions.SigmaRuleLocation("test.yml"))
+        SigmaRule.from_dict(
+            {"title": "test", "name": ""}, source=sigma_exceptions.SigmaRuleLocation("test.yml")
+        )
 
 
 def test_sigmarule_bad_description():
     with pytest.raises(sigma_exceptions.SigmaDescriptionError, match="must be a string.*test.yml"):
         SigmaRule.from_dict(
-            {"description": ["1", "2"]}, source=sigma_exceptions.SigmaRuleLocation("test.yml")
+            {"title": "test", "description": ["1", "2"]},
+            source=sigma_exceptions.SigmaRuleLocation("test.yml"),
         )
 
 
@@ -843,7 +857,9 @@ def test_sigmarule_bad_level():
     with pytest.raises(
         sigma_exceptions.SigmaLevelError, match="no valid Sigma rule level.*test.yml"
     ):
-        SigmaRule.from_dict({"level": "bad"}, source=sigma_exceptions.SigmaRuleLocation("test.yml"))
+        SigmaRule.from_dict(
+            {"title": "test", "level": "bad"}, source=sigma_exceptions.SigmaRuleLocation("test.yml")
+        )
 
 
 def test_sigmarule_bad_status():
@@ -851,7 +867,8 @@ def test_sigmarule_bad_status():
         sigma_exceptions.SigmaStatusError, match="no valid Sigma rule status.*test.yml"
     ):
         SigmaRule.from_dict(
-            {"status": "bad"}, source=sigma_exceptions.SigmaRuleLocation("test.yml")
+            {"title": "test", "status": "bad"},
+            source=sigma_exceptions.SigmaRuleLocation("test.yml"),
         )
 
 
@@ -860,19 +877,23 @@ def test_sigmarule_bad_status_type():
         sigma_exceptions.SigmaStatusError, match="Sigma rule status cannot be a list.*test.yml"
     ):
         SigmaRule.from_dict(
-            {"status": ["test"]}, source=sigma_exceptions.SigmaRuleLocation("test.yml")
+            {"title": "test", "status": ["test"]},
+            source=sigma_exceptions.SigmaRuleLocation("test.yml"),
         )
 
 
 def test_sigmarule_bad_date():
     with pytest.raises(sigma_exceptions.SigmaDateError, match="Rule date.*test.yml"):
-        SigmaRule.from_dict({"date": "bad"}, source=sigma_exceptions.SigmaRuleLocation("test.yml"))
+        SigmaRule.from_dict(
+            {"title": "test", "date": "bad"}, source=sigma_exceptions.SigmaRuleLocation("test.yml")
+        )
 
 
 def test_sigmarule_bad_modified():
     with pytest.raises(sigma_exceptions.SigmaModifiedError, match="Rule modified.*test.yml"):
         SigmaRule.from_dict(
-            {"modified": "bad"}, source=sigma_exceptions.SigmaRuleLocation("test.yml")
+            {"title": "test", "modified": "bad"},
+            source=sigma_exceptions.SigmaRuleLocation("test.yml"),
         )
 
 
@@ -882,7 +903,8 @@ def test_sigmarule_bad_falsepositives():
         match="Sigma rule falsepositives must be a list.*test.yml",
     ):
         SigmaRule.from_dict(
-            {"falsepositives": "bad"}, source=sigma_exceptions.SigmaRuleLocation("test.yml")
+            {"title": "test", "falsepositives": "bad"},
+            source=sigma_exceptions.SigmaRuleLocation("test.yml"),
         )
 
 
@@ -892,7 +914,30 @@ def test_sigmarule_bad_references():
         match="Sigma rule references must be a list.*test.yml",
     ):
         SigmaRule.from_dict(
-            {"references": "bad"}, source=sigma_exceptions.SigmaRuleLocation("test.yml")
+            {"title": "test", "references": "bad"},
+            source=sigma_exceptions.SigmaRuleLocation("test.yml"),
+        )
+
+
+def test_sigmarule_bad_license():
+    with pytest.raises(
+        sigma_exceptions.SigmaLicenseError,
+        match="Sigma rule license must be a string.*test.yml",
+    ):
+        SigmaRule.from_dict(
+            {"title": "test", "license": 1234},
+            source=sigma_exceptions.SigmaRuleLocation("test.yml"),
+        )
+
+
+def test_sigmarule_bad_scope():
+    with pytest.raises(
+        sigma_exceptions.SigmaScopeError,
+        match="Sigma rule scope must be a list.*test.yml",
+    ):
+        SigmaRule.from_dict(
+            {"title": "test", "scope": "windows AD"},
+            source=sigma_exceptions.SigmaRuleLocation("test.yml"),
         )
 
 

--- a/tests/test_validators_tags.py
+++ b/tests/test_validators_tags.py
@@ -24,6 +24,8 @@ from sigma.validators.core.tags import (
     InvalidPatternTagIssue,
     NamespaceTagValidator,
     InvalidNamespaceTagIssue,
+    TagFormatValidator,
+    InvalidTagFormatIssue,
 )
 
 
@@ -233,6 +235,18 @@ def test_validator_duplicate_tags():
             ],
             [],
             InvalidNamespaceTagIssue,
+        ),
+        (
+            TagFormatValidator,
+            ["custom.my tag", "custom.my2tag"],
+            ["custom.my tag"],
+            InvalidTagFormatIssue,
+        ),
+        (
+            TagFormatValidator,
+            ["custom.my_tag", "custom.my-tag"],
+            [],
+            InvalidTagFormatIssue,
         ),
     ],
 )


### PR DESCRIPTION
Taking into account Specification V2 : 

- Add missing [license](https://github.com/SigmaHQ/sigma-specification/blob/main/specification/sigma-rules-specification.md#license)
- Add missing [scope](https://github.com/SigmaHQ/sigma-specification/blob/main/specification/sigma-rules-specification.md#scope)
- Enforce logsource `definition` is a string 
- Add tag syntax validator (https://github.com/SigmaHQ/sigma-specification/blob/main/specification/sigma-rules-specification.md#tags)

class SigmaRuleBase:
- use the "rule_xx" pattern for level and status 
- Check date with `-` before `/` now
- order field like the Specification  (easier for newcomers) , add missing title in the tests