### PR TITLE
Fix: too many backslashes dropped in regular expressions

### DIFF
--- a/sigma/rule.py
+++ b/sigma/rule.py
@@ -9,6 +9,7 @@ import sigma
 from sigma.types import SigmaType, SigmaNull, SigmaString, SigmaNumber, sigma_type
 from sigma.modifiers import (
     SigmaModifier,
+    SigmaRegularExpressionModifier,
     modifier_mapping,
     reverse_modifier_mapping,
     SigmaValueModifier,
@@ -369,7 +370,14 @@ class SigmaDetectionItem(ProcessingItemTrackingMixin, ParentChainMixin):
             val = [None]
 
         # Map Python types to Sigma typing classes
-        val = [sigma_type(v) for v in val]
+        val = [
+            (
+                SigmaString.from_str(v)
+                if SigmaRegularExpressionModifier in modifiers
+                else sigma_type(v)
+            )
+            for v in val
+        ]
 
         return cls(field, modifiers, val, source=source)
 

--- a/sigma/types.py
+++ b/sigma/types.py
@@ -148,6 +148,13 @@ class SigmaString(SigmaType):
             r.append(acc)
         self.s = tuple(r)
 
+    @classmethod
+    def from_str(cls, s: str) -> "SigmaString":
+        sigma_string = SigmaString()
+        sigma_string.s = (s,)
+        sigma_string.original = s
+        return sigma_string
+
     def __getitem__(self, idx: Union[int, slice]) -> "SigmaString":
         """
         Index SigmaString parts with transparent handling of special characters.

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -349,6 +349,13 @@ def test_sigmadetectionitem_key_value_single_regexp_to_plain():
     }
 
 
+def test_sigmadetectionitem_key_value_single_regexp_trailing_backslashes_to_plain():
+    """Key-value detection with one value."""
+    assert SigmaDetectionItem.from_mapping("key|re", "reg.*exp\\\\").to_plain() == {
+        "key|re": "reg.*exp\\\\"
+    }
+
+
 def test_sigmadetectionitem_key_value_list():
     """Key-value detection with value list."""
     assert SigmaDetectionItem.from_mapping("key", ["string", 123]) == SigmaDetectionItem(

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -117,6 +117,10 @@ def test_strings_escaping_end():
     assert SigmaString("finalescape\\").s == ("finalescape\\",)
 
 
+def test_strings_from_str():
+    assert SigmaString.from_str("test*string\\\\") == SigmaString("test\*string\\\\\\\\")
+
+
 def test_string_placeholders_single():
     assert SigmaString("test1%var%test2").insert_placeholders().s == (
         "test1",

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -492,6 +492,10 @@ def test_re_to_plain():
     assert SigmaRegularExpression("test.*").to_plain() == "test.*"
 
 
+def test_re_to_plain_trailing_backslash():
+    assert SigmaRegularExpression("test\\\\").to_plain() == "test\\\\"
+
+
 def test_re_invalid():
     with pytest.raises(SigmaRegularExpressionError):
         SigmaRegularExpression("(test.*")


### PR DESCRIPTION
Fixes sigma.exceptions.SigmaRegularExpressionError: Regular expression 'X' is invalid: bad escape (end of pattern) at position Y #249