### PR TITLE
Taking into account Specification V2

### DIFF
--- a/sigma/exceptions.py
+++ b/sigma/exceptions.py
@@ -55,20 +55,20 @@ class SigmaError(ValueError):
             return False
 
 
-class SigmaTitleError(SigmaError):
-    """Error in Sigma rule title"""
+class SigmaValueError(SigmaError):
+    """Error in Sigma rule value"""
 
     pass
 
 
-class SigmaLogsourceError(SigmaError):
-    """Error in Sigma rule logsource"""
+class SigmaBackendError(SigmaError):
+    """Error in Sigma backend."""
 
     pass
 
 
-class SigmaDetectionError(SigmaError):
-    """Error in Sigma rule detection"""
+class SigmaCollectionError(SigmaError):
+    """Error in Sigma collection, e.g. unknown action"""
 
     pass
 
@@ -79,74 +79,31 @@ class SigmaConditionError(SigmaError):
     pass
 
 
-class SigmaIdentifierError(SigmaError):
-    """Error in Sigma rule identifier"""
+class SigmaConfigurationError(SigmaError):
+    """Error in configuration of a Sigma processing pipeline"""
 
     pass
 
 
-class SigmaNameError(SigmaError):
-    """Error in Sigma rule name"""
+class SigmaConversionError(SigmaError):
+    """Rule conversion failed."""
+
+    def __init__(self, rule: "sigma.rule.SigmaRuleBase", *args, **kwargs):
+        self.rule = rule
+        super().__init__(*args, **kwargs)
+
+    def __str__(self):
+        return super().__str__() + " in rule " + str(self.rule)
+
+
+class SigmaDetectionError(SigmaError):
+    """Error in Sigma rule detection"""
 
     pass
 
 
-class SigmaAuthorError(SigmaError):
-    """Error in Sigma rule author"""
-
-    pass
-
-
-class SigmaRelatedError(SigmaError):
-    """Error in Sigma rule related field"""
-
-    pass
-
-
-class SigmaDateError(SigmaError):
-    """Error in Sigma rule date"""
-
-    pass
-
-
-class SigmaModifiedError(SigmaError):
-    """Error in Sigma rule modified field"""
-
-    pass
-
-
-class SigmaDescriptionError(SigmaError):
-    """Error in Sigma rule description"""
-
-    pass
-
-
-class SigmaReferencesError(SigmaError):
-    """Error in Sigma rule references"""
-
-    pass
-
-
-class SigmaFieldsError(SigmaError):
-    """Error in Sigma rule fields field"""
-
-    pass
-
-
-class SigmaFalsePositivesError(SigmaError):
-    """Error in Sigma rule falsepositives field"""
-
-    pass
-
-
-class SigmaStatusError(SigmaError):
-    """Error in Sigma rule status"""
-
-    pass
-
-
-class SigmaLevelError(SigmaError):
-    """Error in Sigma rule level"""
+class SigmaFeatureNotSupportedByBackendError(SigmaError):
+    """Sigma feature is not supported by the backend."""
 
     pass
 
@@ -157,20 +114,34 @@ class SigmaModifierError(SigmaError):
     pass
 
 
-class SigmaTypeError(SigmaModifierError):
-    """Sigma modifier not applicable on value type"""
+class SigmaPipelineNotAllowedForBackendError(SigmaConfigurationError):
+    """One or multiple processing pipelines doesn't matches the given backend."""
 
-    pass
+    def __init__(self, spec: str, backend: str, *args, **kwargs):
+        self.wrong_pipeline = spec
+        self.backend = backend
+        super().__init__(*args, **kwargs)
+
+    def __str__(self):
+        return (
+            f"Processing pipelines not allowed for backend '{self.backend}': {self.wrong_pipeline}"
+        )
 
 
-class SigmaValueError(SigmaError):
-    """Error in Sigma rule value"""
+class SigmaPipelineNotFoundError(SigmaError, ValueError):
+    """An attempt to resolve a processing pipeline from a specifier failed because it was not
+    found."""
 
-    pass
+    def __init__(self, spec: str, *args, **kwargs):
+        self.spec = spec
+        super().__init__(*args, **kwargs)
+
+    def __str__(self):
+        return f"Processing pipeline '{self.spec}' not found"
 
 
-class SigmaRegularExpressionError(SigmaValueError):
-    """Error in regular expression contained in Sigma rule"""
+class SigmaPipelineParsingError(SigmaError):
+    """Error in parsing of a Sigma processing pipeline"""
 
     pass
 
@@ -181,20 +152,41 @@ class SigmaPlaceholderError(SigmaValueError):
     pass
 
 
+class SigmaPluginNotFoundError(SigmaError):
+    """Plugin was not found."""
+
+    pass
+
+
+class SigmaRegularExpressionError(SigmaValueError):
+    """Error in regular expression contained in Sigma rule"""
+
+    pass
+
+
+class SigmaTransformationError(SigmaError):
+    """Error while transformation. Can be raised intentionally by FailureTransformation."""
+
+    pass
+
+
+class SigmaTypeError(SigmaModifierError):
+    """Sigma modifier not applicable on value type"""
+
+    pass
+
+
+class SigmaValidatorConfigurationParsingError(SigmaError):
+    """Error in parsing of a Sigma validation configuration file."""
+
+    pass
+
+
+# Meta Rule Correlation Error
+
+
 class SigmaCorrelationRuleError(SigmaValueError):
     """Error in Sigma correlation rule."""
-
-    pass
-
-
-class SigmaCorrelationTypeError(SigmaCorrelationRuleError):
-    """Wrong Sigma correlation type."""
-
-    pass
-
-
-class SigmaRuleNotFoundError(SigmaCorrelationRuleError):
-    """Sigma rule not found."""
 
     pass
 
@@ -205,10 +197,25 @@ class SigmaCorrelationConditionError(SigmaCorrelationRuleError):
     pass
 
 
+class SigmaCorrelationTypeError(SigmaCorrelationRuleError):
+    """Wrong Sigma correlation type."""
+
+    pass
+
+
 class SigmaTimespanError(SigmaCorrelationRuleError):
     """Raised when the timespan for calculating sigma is invalid."""
 
     pass
+
+
+class SigmaRuleNotFoundError(SigmaCorrelationRuleError):
+    """Sigma rule not found."""
+
+    pass
+
+
+# Meta Filter Error
 
 
 class SigmaFilterError(SigmaValueError):
@@ -229,83 +236,103 @@ class SigmaFilterRuleReferenceError(SigmaFilterError):
     pass
 
 
-class SigmaCollectionError(SigmaError):
-    """Error in Sigma collection, e.g. unknown action"""
+# Rule Fields error
+
+
+class SigmaAuthorError(SigmaError):
+    """Error in Sigma rule author"""
 
     pass
 
 
-class SigmaConfigurationError(SigmaError):
-    """Error in configuration of a Sigma processing pipeline"""
+class SigmaDateError(SigmaError):
+    """Error in Sigma rule date"""
 
     pass
 
 
-class SigmaValidatorConfigurationParsingError(SigmaError):
-    """Error in parsing of a Sigma validation configuration file."""
+class SigmaDescriptionError(SigmaError):
+    """Error in Sigma rule description"""
 
     pass
 
 
-class SigmaFeatureNotSupportedByBackendError(SigmaError):
-    """Sigma feature is not supported by the backend."""
+class SigmaFalsePositivesError(SigmaError):
+    """Error in Sigma rule falsepositives field"""
 
     pass
 
 
-class SigmaPipelineParsingError(SigmaError):
-    """Error in parsing of a Sigma processing pipeline"""
+class SigmaFieldsError(SigmaError):
+    """Error in Sigma rule fields field"""
 
     pass
 
 
-class SigmaPipelineNotFoundError(SigmaError, ValueError):
-    """An attempt to resolve a processing pipeline from a specifier failed because it was not
-    found."""
+class SigmaIdentifierError(SigmaError):
+    """Error in Sigma rule identifier"""
 
-    def __init__(self, spec: str, *args, **kwargs):
-        self.spec = spec
-        super().__init__(*args, **kwargs)
-
-    def __str__(self):
-        return f"Processing pipeline '{self.spec}' not found"
+    pass
 
 
-class SigmaPipelineNotAllowedForBackendError(SigmaConfigurationError):
-    """One or multiple processing pipelines doesn't matches the given backend."""
+class SigmaLevelError(SigmaError):
+    """Error in Sigma rule level"""
 
-    def __init__(self, spec: str, backend: str, *args, **kwargs):
-        self.wrong_pipeline = spec
-        self.backend = backend
-        super().__init__(*args, **kwargs)
-
-    def __str__(self):
-        return (
-            f"Processing pipelines not allowed for backend '{self.backend}': {self.wrong_pipeline}"
-        )
+    pass
 
 
-class SigmaTransformationError(SigmaError):
-    """Error while transformation. Can be raised intentionally by FailureTransformation."""
+class SigmaLicenseError(SigmaError):
+    """Error in Sigma rule license"""
+
+    pass
 
 
-class SigmaPluginNotFoundError(SigmaError):
-    """Plugin was not found."""
+class SigmaLogsourceError(SigmaError):
+    """Error in Sigma rule logsource"""
+
+    pass
 
 
-class SigmaConversionError(SigmaError):
-    """Rule conversion failed."""
+class SigmaModifiedError(SigmaError):
+    """Error in Sigma rule modified field"""
 
-    def __init__(self, rule: "sigma.rule.SigmaRuleBase", *args, **kwargs):
-        self.rule = rule
-        super().__init__(*args, **kwargs)
-
-    def __str__(self):
-        return super().__str__() + " in rule " + str(self.rule)
+    pass
 
 
-class SigmaBackendError(SigmaError):
-    """Error in Sigma backend."""
+class SigmaNameError(SigmaError):
+    """Error in Sigma rule name"""
+
+    pass
+
+
+class SigmaReferencesError(SigmaError):
+    """Error in Sigma rule references"""
+
+    pass
+
+
+class SigmaRelatedError(SigmaError):
+    """Error in Sigma rule related field"""
+
+    pass
+
+
+class SigmaScopeError(SigmaError):
+    """Error in Sigma rule scope"""
+
+    pass
+
+
+class SigmaStatusError(SigmaError):
+    """Error in Sigma rule status"""
+
+    pass
+
+
+class SigmaTitleError(SigmaError):
+    """Error in Sigma rule title"""
+
+    pass
 
 
 @dataclass

--- a/sigma/validators/core/tags.py
+++ b/sigma/validators/core/tags.py
@@ -23,6 +23,24 @@ import re
 
 
 @dataclass
+class InvalidTagFormatIssue(SigmaValidationIssue):
+    description: ClassVar[str] = "Invalid char in namaspace or name tag"
+    severity: ClassVar[SigmaValidationIssueSeverity] = SigmaValidationIssueSeverity.MEDIUM
+    tag: SigmaRuleTag
+
+
+class TagFormatValidator(SigmaTagValidator):
+    """Validate rule tag namespace and name allowed char"""
+
+    def validate_tag(self, tag: SigmaRuleTag) -> List[SigmaValidationIssue]:
+        tags_pattern = re.compile(r"^[a-z0-9\-\_]+\.[a-z0-9\-\_\.]+$")
+
+        if tags_pattern.match(str(tag)) is None:
+            return [InvalidTagFormatIssue([self.rule], tag)]
+        return []
+
+
+@dataclass
 class InvalidATTACKTagIssue(SigmaValidationIssue):
     description: ClassVar[str] = "Invalid MITRE ATT&CK tagging"
     severity: ClassVar[SigmaValidationIssueSeverity] = SigmaValidationIssueSeverity.MEDIUM

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -174,6 +174,13 @@ def test_sigmalogsource_empty():
         SigmaLogSource(None, None, None, source=sigma_exceptions.SigmaRuleLocation("test.yml"))
 
 
+def test_sigmalogsource_fromdict_definition_not_str():
+    with pytest.raises(sigma_exceptions.SigmaLogsourceError):
+        SigmaLogSource.from_dict(
+            {"category": "category-id", "definition": ["sysmon", "edr", "siem"]}
+        )
+
+
 def test_sigmalogsource_str():
     with pytest.raises(
         sigma_exceptions.SigmaLogsourceError,
@@ -1519,3 +1526,25 @@ def test_sigma_rule_conversion_result_no_result(sigma_rule):
 def test_sigma_rule_disable_output(sigma_rule):
     sigma_rule.disable_output()
     assert sigma_rule._output == False
+
+
+def test_sigmarule_bad_license():
+    with pytest.raises(
+        sigma_exceptions.SigmaLicenseError,
+        match="Sigma rule license must be a string.*test.yml",
+    ):
+        SigmaRule.from_dict(
+            {"title": "test", "license": 1234},
+            source=sigma_exceptions.SigmaRuleLocation("test.yml"),
+        )
+
+
+def test_sigmarule_bad_scope():
+    with pytest.raises(
+        sigma_exceptions.SigmaScopeError,
+        match="Sigma rule scope must be a list.*test.yml",
+    ):
+        SigmaRule.from_dict(
+            {"title": "test", "scope": "windows AD"},
+            source=sigma_exceptions.SigmaRuleLocation("test.yml"),
+        )

--- a/tests/test_validators_tags.py
+++ b/tests/test_validators_tags.py
@@ -24,6 +24,8 @@ from sigma.validators.core.tags import (
     InvalidPatternTagIssue,
     NamespaceTagValidator,
     InvalidNamespaceTagIssue,
+    TagFormatValidator,
+    InvalidTagFormatIssue,
 )
 
 
@@ -233,6 +235,18 @@ def test_validator_duplicate_tags():
             ],
             [],
             InvalidNamespaceTagIssue,
+        ),
+        (
+            TagFormatValidator,
+            ["custom.my tag", "custom.my2tag"],
+            ["custom.my tag"],
+            InvalidTagFormatIssue,
+        ),
+        (
+            TagFormatValidator,
+            ["custom.my_tag", "custom.my-tag"],
+            [],
+            InvalidTagFormatIssue,
         ),
     ],
 )


### PR DESCRIPTION
Taking into account Specification V2 : 

- Add missing [license](https://github.com/SigmaHQ/sigma-specification/blob/main/specification/sigma-rules-specification.md#license)
- Add missing [scope](https://github.com/SigmaHQ/sigma-specification/blob/main/specification/sigma-rules-specification.md#scope)
- Enforce logsource `definition` is a string 
- Add generic tag syntax validator (https://github.com/SigmaHQ/sigma-specification/blob/main/specification/sigma-rules-specification.md#tags)

class SigmaRuleBase:
- use the "rule_xx" pattern for level and status 
