### PR TITLE
Fix ReplaceStringTransformation and SigmaString plain string conversion

### DIFF
--- a/sigma/processing/transformations.py
+++ b/sigma/processing/transformations.py
@@ -762,14 +762,17 @@ class SetFieldTransformation(Transformation):
 class ReplaceStringTransformation(StringValueTransformation):
     """
     Replace string part matched by regular expresssion with replacement string that can reference
-    capture groups. It operates on the whole string representation of the SigmaString value.
-    Therefore, it is able to replace special characters like wildcards too.
+    capture groups. Normally, the replacement operates on the plain string representation of the
+    SigmaString. This allows also to include special characters and placeholders in the replacement.
+    By enabling the skip_special parameter, the replacement is only applied to the plain string
+    parts of a SigmaString and special characters and placeholders are left untouched.
 
-    This is basically an interface to re.sub() and can use all features available there.
+    The replacement is implemented with re.sub() and can use all features available there.
     """
 
     regex: str
     replacement: str
+    skip_special: bool = False
 
     def __post_init__(self):
         super().__post_init__()
@@ -782,10 +785,15 @@ class ReplaceStringTransformation(StringValueTransformation):
 
     def apply_string_value(self, field: str, val: SigmaString) -> SigmaString:
         if isinstance(val, SigmaString):
-            sigma_string_plain = str(val)
-            replaced = self.re.sub(self.replacement, sigma_string_plain)
-            postprocessed_backslashes = re.sub(r"\\(?![*?])", r"\\\\", replaced)
-            return SigmaString(postprocessed_backslashes)
+            if self.skip_special:
+                return val.map_parts(
+                    lambda s: self.re.sub(self.replacement, s), lambda p: isinstance(p, str)
+                )
+            else:
+                sigma_string_plain = str(val)
+                replaced = self.re.sub(self.replacement, sigma_string_plain)
+                postprocessed_backslashes = re.sub(r"\\(?![*?])", r"\\\\", replaced)
+                return SigmaString(postprocessed_backslashes)
 
 
 @dataclass

--- a/sigma/processing/transformations.py
+++ b/sigma/processing/transformations.py
@@ -762,7 +762,8 @@ class SetFieldTransformation(Transformation):
 class ReplaceStringTransformation(StringValueTransformation):
     """
     Replace string part matched by regular expresssion with replacement string that can reference
-    capture groups. It operates on the plain string parts of the SigmaString value.
+    capture groups. It operates on the whole string representation of the SigmaString value.
+    Therefore, it is able to replace special characters like wildcards too.
 
     This is basically an interface to re.sub() and can use all features available there.
     """
@@ -781,9 +782,10 @@ class ReplaceStringTransformation(StringValueTransformation):
 
     def apply_string_value(self, field: str, val: SigmaString) -> SigmaString:
         if isinstance(val, SigmaString):
-            return val.map_parts(
-                lambda s: self.re.sub(self.replacement, s), lambda p: isinstance(p, str)
-            )
+            sigma_string_plain = str(val)
+            replaced = self.re.sub(self.replacement, sigma_string_plain)
+            postprocessed_backslashes = re.sub(r"\\(?![*?])", r"\\\\", replaced)
+            return SigmaString(postprocessed_backslashes)
 
 
 @dataclass

--- a/sigma/rule.py
+++ b/sigma/rule.py
@@ -432,9 +432,22 @@ class SigmaDetectionItem(ProcessingItemTrackingMixin, ParentChainMixin):
             )
 
         if len(self.original_value) > 1:
-            value = [value.to_plain() for value in self.original_value]
+            value = [
+                (
+                    value.to_plain(True)
+                    if isinstance(value, SigmaString)
+                    and SigmaRegularExpressionModifier in self.modifiers
+                    else value.to_plain()
+                )
+                for value in self.original_value
+            ]
         else:
-            value = self.original_value[0].to_plain()
+            value = (
+                self.original_value[0].to_plain(True)
+                if isinstance(self.original_value[0], SigmaString)
+                and SigmaRegularExpressionModifier in self.modifiers
+                else self.original_value[0].to_plain()
+            )
 
         if (
             self.is_keyword() and len(self.modifiers) == 0

--- a/sigma/types.py
+++ b/sigma/types.py
@@ -355,10 +355,17 @@ class SigmaString(SigmaType):
             )
 
     def __str__(self) -> str:
+        return self.to_plain()
+
+    def to_plain(self, regex: bool = False) -> str:
+        """Generate string representation of SigmaString with or without regex escaping."""
         rs = ""
         for s in self.s:
             if isinstance(s, str):
-                rs += s
+                if regex:
+                    rs += s
+                else:
+                    rs += s.replace("*", "\\*").replace("?", "\\?")
             elif isinstance(s, SpecialChars):
                 rs += special_char_mapping[s]
             elif isinstance(s, Placeholder):
@@ -372,9 +379,9 @@ class SigmaString(SigmaType):
     def __repr__(self) -> str:
         return str(f"SigmaString({self.s})")
 
-    def to_plain(self):
-        """Return plain string representation of SigmaString, equivalent to converting it with str()."""
-        return str(self)
+    def to_plain_regex(self):
+        """Return plain string representation of SigmaString with reduced escaping."""
+        return self._stringify(True)
 
     def __bytes__(self) -> bytes:
         return str(self).encode()

--- a/tests/test_processing_transformations.py
+++ b/tests/test_processing_transformations.py
@@ -1348,8 +1348,40 @@ def test_replace_string_specials(dummy_pipeline):
         [
             SigmaDetection(
                 [
-                    SigmaDetectionItem("field1", [], [SigmaString("*/value")]),
+                    SigmaDetectionItem("field1", [], [SigmaString("/value")]),
                     SigmaDetectionItem("field2", [], [SigmaNumber(123)]),
+                ]
+            )
+        ]
+    )
+
+
+def test_replace_string_backslashes(dummy_pipeline):
+    sigma_rule = SigmaRule.from_dict(
+        {
+            "title": "Test",
+            "logsource": {"category": "test"},
+            "detection": {
+                "test": [
+                    {
+                        "field1": r"backslash\\value",
+                        "field2": r"backslash\\\\value",
+                        "field3": r"plainwildcard\*value",
+                    }
+                ],
+                "condition": "test",
+            },
+        }
+    )
+    transformation = ReplaceStringTransformation("value", "test")
+    transformation.apply(dummy_pipeline, sigma_rule)
+    assert sigma_rule.detection.detections["test"] == SigmaDetection(
+        [
+            SigmaDetection(
+                [
+                    SigmaDetectionItem("field1", [], [SigmaString(r"backslash\\test")]),
+                    SigmaDetectionItem("field2", [], [SigmaString(r"backslash\\\\test")]),
+                    SigmaDetectionItem("field3", [], [SigmaString(r"plainwildcard\*test")]),
                 ]
             )
         ]

--- a/tests/test_processing_transformations.py
+++ b/tests/test_processing_transformations.py
@@ -1356,6 +1356,36 @@ def test_replace_string_specials(dummy_pipeline):
     )
 
 
+def test_replace_string_skip_specials(dummy_pipeline):
+    sigma_rule = SigmaRule.from_dict(
+        {
+            "title": "Test",
+            "logsource": {"category": "test"},
+            "detection": {
+                "test": [
+                    {
+                        "field1": "*\\value",
+                        "field2": 123,
+                    }
+                ],
+                "condition": "test",
+            },
+        }
+    )
+    transformation = ReplaceStringTransformation("^.*\\\\", "/", True)
+    transformation.apply(dummy_pipeline, sigma_rule)
+    assert sigma_rule.detection.detections["test"] == SigmaDetection(
+        [
+            SigmaDetection(
+                [
+                    SigmaDetectionItem("field1", [], [SigmaString("*/value")]),
+                    SigmaDetectionItem("field2", [], [SigmaNumber(123)]),
+                ]
+            )
+        ]
+    )
+
+
 def test_replace_string_backslashes(dummy_pipeline):
     sigma_rule = SigmaRule.from_dict(
         {

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -320,6 +320,20 @@ def test_strings_to_string():
     assert str(SigmaString("test*?")) == "test*?"
 
 
+def test_strings_with_plain_wildcards_to_string():
+    plain_s = "value\*with\?plain*wild?cards"
+    s = SigmaString(plain_s)
+    assert s.s == (
+        "value*with?plain",
+        SpecialChars.WILDCARD_MULTI,
+        "wild",
+        SpecialChars.WILDCARD_SINGLE,
+        "cards",
+    )
+    assert str(s) == plain_s
+    assert SigmaString(str(s)) == s
+
+
 def test_strings_with_placeholder_to_string():
     assert str(SigmaString("te%var%st").insert_placeholders()) == "te%var%st"
 


### PR DESCRIPTION
This pull request fixes the behavior of the ReplaceStringTransformation and SigmaString classes. The ReplaceStringTransformation now works on the plain string representation of the SigmaString, allowing for special characters and placeholders in the replacement. Additionally, the SigmaString class now distinguishes between regex and string context in the to_plain() method and behaves differently on escaping. The pull request also includes an option in the ReplaceStringTransformation to skip special characters in the replacement.