### PR TITLE
Remove optional fields validator

### DIFF
--- a/sigma/validators/core/metadata.py
+++ b/sigma/validators/core/metadata.py
@@ -114,54 +114,6 @@ class DuplicateReferencesValidator(SigmaRuleValidator):
 
 
 @dataclass
-class StatusExistenceIssue(SigmaValidationIssue):
-    description: ClassVar[str] = "Rule has no status"
-    severity: ClassVar[SigmaValidationIssueSeverity] = SigmaValidationIssueSeverity.MEDIUM
-
-
-class StatusExistenceValidator(SigmaRuleValidator):
-    """Checks if rule has a status."""
-
-    def validate(self, rule: SigmaRule) -> List[SigmaValidationIssue]:
-        if rule.status is None:
-            return [StatusExistenceIssue([rule])]
-        else:
-            return []
-
-
-@dataclass
-class StatusUnsupportedIssue(SigmaValidationIssue):
-    description: ClassVar[str] = "Rule has UNSUPPORTED status"
-    severity: ClassVar[SigmaValidationIssueSeverity] = SigmaValidationIssueSeverity.MEDIUM
-
-
-class StatusUnsupportedValidator(SigmaRuleValidator):
-    """Checks if rule has a status UNSUPPORTED."""
-
-    def validate(self, rule: SigmaRule) -> List[SigmaValidationIssue]:
-        if rule.status and rule.status.name == "UNSUPPORTED":
-            return [StatusUnsupportedIssue([rule])]
-        else:
-            return []
-
-
-@dataclass
-class DateExistenceIssue(SigmaValidationIssue):
-    description: ClassVar[str] = "Rule has no date"
-    severity: ClassVar[SigmaValidationIssueSeverity] = SigmaValidationIssueSeverity.MEDIUM
-
-
-class DateExistenceValidator(SigmaRuleValidator):
-    """Checks if rule has a data."""
-
-    def validate(self, rule: SigmaRule) -> List[SigmaValidationIssue]:
-        if rule.date is None:
-            return [DateExistenceIssue([rule])]
-        else:
-            return []
-
-
-@dataclass
 class DuplicateFilenameIssue(SigmaValidationIssue):
     description: ClassVar[str] = "Rule filename used by multiple rules"
     severity: ClassVar[SigmaValidationIssueSeverity] = SigmaValidationIssueSeverity.HIGH
@@ -238,54 +190,3 @@ class CustomAttributesValidator(SigmaRuleValidator):
                 if k in self.known_custom_attributes:
                     return [CustomAttributesIssue(rule, k)]
         return []
-
-
-@dataclass
-class DescriptionExistenceIssue(SigmaValidationIssue):
-    description: ClassVar[str] = "Rule has no description"
-    severity: ClassVar[SigmaValidationIssueSeverity] = SigmaValidationIssueSeverity.MEDIUM
-
-
-class DescriptionExistenceValidator(SigmaRuleValidator):
-    """Checks if rule has a description."""
-
-    def validate(self, rule: SigmaRule) -> List[SigmaValidationIssue]:
-        if rule.description is None:
-            return [DescriptionExistenceIssue([rule])]
-        else:
-            return []
-
-
-@dataclass
-class DescriptionLengthIssue(SigmaValidationIssue):
-    description: ClassVar[str] = "Rule has a too short description"
-    severity: ClassVar[SigmaValidationIssueSeverity] = SigmaValidationIssueSeverity.MEDIUM
-
-
-@dataclass(frozen=True)
-class DescriptionLengthValidator(SigmaRuleValidator):
-    """Checks if rule has a description."""
-
-    min_length: int = 16
-
-    def validate(self, rule: SigmaRule) -> List[SigmaValidationIssue]:
-        if rule.description is not None and len(rule.description) < self.min_length:
-            return [DescriptionLengthIssue([rule])]
-        else:
-            return []
-
-
-@dataclass
-class LevelExistenceIssue(SigmaValidationIssue):
-    description: ClassVar[str] = "Rule has no level"
-    severity: ClassVar[SigmaValidationIssueSeverity] = SigmaValidationIssueSeverity.MEDIUM
-
-
-class LevelExistenceValidator(SigmaRuleValidator):
-    """Checks if rule has a level."""
-
-    def validate(self, rule: SigmaRule) -> List[SigmaValidationIssue]:
-        if rule.level is None:
-            return [LevelExistenceIssue([rule])]
-        else:
-            return []

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -10,7 +10,6 @@ from sigma.validators.core.values import NumberAsStringValidator
 from tests.test_validators import rule_with_id, rule_without_id, rules_with_id_collision
 from sigma.collection import SigmaCollection
 from sigma.validators.core.metadata import (
-    DescriptionLengthValidator,
     IdentifierExistenceValidator,
     IdentifierUniquenessValidator,
     IdentifierExistenceIssue,
@@ -81,17 +80,11 @@ def test_sigmavalidator_from_dict(validators):
                     "number_as_string",
                 ],
             },
-            "config": {
-                "description_length": {
-                    "min_length": 100,
-                },
-            },
         },
         validators,
     )
     assert DanglingDetectionValidator in (v.__class__ for v in validator.validators)
     assert TLPv1TagValidator not in (v.__class__ for v in validator.validators)
-    assert DescriptionLengthValidator(min_length=100) in validator.validators
     assert len(validator.validators) >= 10
     assert validator.exclusions == {
         UUID("c702c6c7-1393-40e5-93f8-91469f3445ad"): {DanglingDetectionValidator},
@@ -114,15 +107,11 @@ def test_sigmavalidator_from_yaml(validators):
         bf39335e-e666-4eaf-9416-47f1955b5fb3:
             - attacktag
             - number_as_string
-    config:
-        description_length:
-            min_length: 100
     """,
         validators,
     )
     assert DanglingDetectionValidator in (v.__class__ for v in validator.validators)
     assert TLPv1TagValidator not in (v.__class__ for v in validator.validators)
-    assert DescriptionLengthValidator(min_length=100) in validator.validators
     assert len(validator.validators) >= 10
     assert validator.exclusions == {
         UUID("c702c6c7-1393-40e5-93f8-91469f3445ad"): {DanglingDetectionValidator},

--- a/tests/test_validators_metadata.py
+++ b/tests/test_validators_metadata.py
@@ -13,24 +13,12 @@ from sigma.validators.core.metadata import (
     DuplicateTitleValidator,
     DuplicateReferencesIssue,
     DuplicateReferencesValidator,
-    StatusExistenceValidator,
-    StatusExistenceIssue,
-    StatusUnsupportedValidator,
-    StatusUnsupportedIssue,
-    DateExistenceValidator,
-    DateExistenceIssue,
     DuplicateFilenameValidator,
     DuplicateFilenameIssue,
     FilenameLengthValidator,
     FilenameLengthIssue,
     CustomAttributesValidator,
     CustomAttributesIssue,
-    DescriptionExistenceValidator,
-    DescriptionExistenceIssue,
-    DescriptionLengthValidator,
-    DescriptionLengthIssue,
-    LevelExistenceValidator,
-    LevelExistenceIssue,
 )
 
 
@@ -202,106 +190,6 @@ def test_validator_duplicate_references_valid():
     assert validator.validate(rule) == []
 
 
-def test_validator_status_existence():
-    validator = StatusExistenceValidator()
-    rule = SigmaRule.from_yaml(
-        """
-    title: Test
-    logsource:
-        category: test
-    detection:
-        sel:
-            field: value
-        condition: sel
-    """
-    )
-    assert validator.validate(rule) == [StatusExistenceIssue([rule])]
-
-
-def test_validator_status_existence_valid():
-    validator = StatusExistenceValidator()
-    rule = SigmaRule.from_yaml(
-        """
-    title: Test
-    status: stable
-    logsource:
-        category: test
-    detection:
-        sel:
-            field: value
-        condition: sel
-    """
-    )
-    assert validator.validate(rule) == []
-
-
-def test_validator_status_unsupported():
-    validator = StatusUnsupportedValidator()
-    rule = SigmaRule.from_yaml(
-        """
-    title: Test
-    status: unsupported
-    logsource:
-        category: test
-    detection:
-        sel:
-            field: value
-        condition: sel
-    """
-    )
-    assert validator.validate(rule) == [StatusUnsupportedIssue([rule])]
-
-
-def test_validator_status_unsupported_valid():
-    validator = StatusUnsupportedValidator()
-    rule = SigmaRule.from_yaml(
-        """
-    title: Test
-    status: stable
-    logsource:
-        category: test
-    detection:
-        sel:
-            field: value
-        condition: sel
-    """
-    )
-    assert validator.validate(rule) == []
-
-
-def test_validator_date_existence():
-    validator = DateExistenceValidator()
-    rule = SigmaRule.from_yaml(
-        """
-    title: Test
-    logsource:
-        category: test
-    detection:
-        sel:
-            field: value
-        condition: sel
-    """
-    )
-    assert validator.validate(rule) == [DateExistenceIssue([rule])]
-
-
-def test_validator_date_existence_valid():
-    validator = DateExistenceValidator()
-    rule = SigmaRule.from_yaml(
-        """
-    title: Test
-    date: 2023-12-11
-    logsource:
-        category: test
-    detection:
-        sel:
-            field: value
-        condition: sel
-    """
-    )
-    assert validator.validate(rule) == []
-
-
 def test_validator_duplicate_filename():
     validator = DuplicateFilenameValidator()
     sigma_collection = SigmaCollection.load_ruleset(["tests/files/ruleset_duplicate"])
@@ -373,123 +261,6 @@ def test_validator_custom_attributes_valid():
         sel:
             field: value
         condition: sel
-    """
-    )
-    assert validator.validate(rule) == []
-
-
-def test_validator_description_existence():
-    validator = DescriptionExistenceValidator()
-    rule = SigmaRule.from_yaml(
-        """
-    title: Test
-    logsource:
-        category: test
-    detection:
-        sel:
-            field: value
-        condition: sel
-    """
-    )
-    assert validator.validate(rule) == [DescriptionExistenceIssue([rule])]
-
-
-def test_validator_description_existence_valid():
-    validator = DescriptionExistenceValidator()
-    rule = SigmaRule.from_yaml(
-        """
-    title: Test
-    description: it is a simple description
-    logsource:
-        category: test
-    detection:
-        sel:
-            field: value
-        condition: sel
-    """
-    )
-    assert validator.validate(rule) == []
-
-
-def test_validator_description_length():
-    validator = DescriptionLengthValidator()
-    rule = SigmaRule.from_yaml(
-        """
-    title: Test
-    description: Test
-    logsource:
-        category: test
-    detection:
-        sel:
-            field: value
-        condition: sel
-    """
-    )
-    assert validator.validate(rule) == [DescriptionLengthIssue([rule])]
-
-
-def test_validator_description_length_valid():
-    validator = DescriptionLengthValidator()
-    rule = SigmaRule.from_yaml(
-        """
-    title: Test
-    description: it is a simple description
-    logsource:
-        category: test
-    detection:
-        sel:
-            field: value
-        condition: sel
-    """
-    )
-    assert validator.validate(rule) == []
-
-
-def test_validator_description_length_valid_customized():
-    validator = DescriptionLengthValidator(min_length=999)
-    rule = SigmaRule.from_yaml(
-        """
-    title: Test
-    description: it is a simple description
-    logsource:
-        category: test
-    detection:
-        sel:
-            field: value
-        condition: sel
-    """
-    )
-    assert validator.validate(rule) == [DescriptionLengthIssue([rule])]
-
-
-def test_validator_level_existence():
-    validator = LevelExistenceValidator()
-    rule = SigmaRule.from_yaml(
-        """
-    title: Test
-    logsource:
-        category: test
-    detection:
-        sel:
-            field: value
-        condition: sel
-    """
-    )
-    assert validator.validate(rule) == [LevelExistenceIssue([rule])]
-
-
-def test_validator_level_existence_valid():
-    validator = LevelExistenceValidator()
-    rule = SigmaRule.from_yaml(
-        """
-    title: Test
-    logsource:
-        category: test
-    detection:
-        sel:
-            field: value
-        condition: sel
-    level: medium
     """
     )
     assert validator.validate(rule) == []


### PR DESCRIPTION
Remove validator for optional field from [V2 specification](https://github.com/SigmaHQ/sigma-specification/blob/main/specification/sigma-rules-specification.md)

- StatusExistenceValidator
- StatusUnsupportedValidator
- DateExistenceValidator
- DescriptionExistenceValidator
- DescriptionLengthValidator
- LevelExistenceValidator

All of them are in the pySigma-validators-sigmaHQ 0.7.0