### PR TITLE
String pattern to regular excpression conversion

### DIFF
--- a/sigma/types.py
+++ b/sigma/types.py
@@ -565,6 +565,17 @@ class SigmaString(SigmaType):
                 )
         return s
 
+    def to_regex(self) -> "SigmaRegularExpression":
+        """Convert SigmaString into a regular expression."""
+        return SigmaRegularExpression(
+            self.convert(
+                escape_char="\\",
+                wildcard_multi=".*",
+                wildcard_single=".",
+                add_escaped=".*+?^$[](){}\\|",
+            )
+        )
+
 
 class SigmaCasedString(SigmaString):
     """Case-sensitive string matching."""

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -388,6 +388,19 @@ def test_strings_convert_invalid_part():
         s.convert()
 
 
+def test_strings_to_regex():
+    s = SigmaString("Test*Special?(Plain)[\\*\\?]")
+    assert s.s == (
+        "Test",
+        SpecialChars.WILDCARD_MULTI,
+        "Special",
+        SpecialChars.WILDCARD_SINGLE,
+        "(Plain)[*?]",
+    )
+    r = s.to_regex()
+    assert r.regexp == "Test.*Special.\\(Plain\\)\\[\\*\\?\\]"
+
+
 def test_string_index(sigma_string):
     assert sigma_string[3] == SigmaString("s")
 


### PR DESCRIPTION
The `TextQueryBackend` base class now offer as `regex` template variable that contains the regular expression representation of a string pattern for these backends that don't support regular expressions instead of patterns.