### PR TITLE
Allow special characters in startswith, endswith, and contains expressions

### DIFF
--- a/sigma/conversion/base.py
+++ b/sigma/conversion/base.py
@@ -807,8 +807,11 @@ class TextQueryBackend(Backend):
 
     # String matching operators. if none is appropriate eq_token is used.
     startswith_expression: ClassVar[Optional[str]] = None
+    startswith_expression_allow_special: ClassVar[bool] = False
     endswith_expression: ClassVar[Optional[str]] = None
+    endswith_expression_allow_special: ClassVar[bool] = False
     contains_expression: ClassVar[Optional[str]] = None
+    contains_expression_allow_special: ClassVar[bool] = False
     wildcard_match_expression: ClassVar[Optional[str]] = (
         None  # Special expression if wildcards can't be matched with the eq_token operator.
     )
@@ -1309,9 +1312,10 @@ class TextQueryBackend(Backend):
                 self.startswith_expression
                 is not None  # 'startswith' operator is defined in backend
                 and cond.value.endswith(SpecialChars.WILDCARD_MULTI)  # String ends with wildcard
-                and not cond.value[
-                    :-1
-                ].contains_special()  # Remainder of string doesn't contains special characters
+                and (
+                    self.startswith_expression_allow_special
+                    or not cond.value[:-1].contains_special()
+                )  # Remainder of string doesn't contains special characters or it's allowed
             ):
                 expr = (
                     self.startswith_expression
@@ -1320,7 +1324,9 @@ class TextQueryBackend(Backend):
             elif (  # Same as above but for 'endswith' operator: string starts with wildcard and doesn't contains further special characters
                 self.endswith_expression is not None
                 and cond.value.startswith(SpecialChars.WILDCARD_MULTI)
-                and not cond.value[1:].contains_special()
+                and (
+                    self.endswith_expression_allow_special or not cond.value[1:].contains_special()
+                )
             ):
                 expr = self.endswith_expression
                 value = cond.value[1:]
@@ -1328,7 +1334,10 @@ class TextQueryBackend(Backend):
                 self.contains_expression is not None
                 and cond.value.startswith(SpecialChars.WILDCARD_MULTI)
                 and cond.value.endswith(SpecialChars.WILDCARD_MULTI)
-                and not cond.value[1:-1].contains_special()
+                and (
+                    self.contains_expression_allow_special
+                    or not cond.value[1:-1].contains_special()
+                )
             ):
                 expr = self.contains_expression
                 value = cond.value[1:-1]

--- a/tests/test_conversion_base.py
+++ b/tests/test_conversion_base.py
@@ -351,6 +351,49 @@ def test_convert_value_str_startswith_further_wildcard_allowed(test_backend, mon
     )
 
 
+def test_convert_value_str_startswith_cased_further_wildcard(test_backend):
+    assert (
+        test_backend.convert(
+            SigmaCollection.from_yaml(
+                """
+            title: Test
+            status: test
+            logsource:
+                category: test_category
+                product: test_product
+            detection:
+                sel:
+                    "field|startswith|cased": "va*lue"
+                condition: sel
+        """
+            )
+        )
+        == ['field casematch "va*lue*"']
+    )
+
+
+def test_convert_value_str_startswith_cased_further_wildcard_allowed(test_backend, monkeypatch):
+    monkeypatch.setattr(test_backend, "case_sensitive_startswith_expression_allow_special", True)
+    assert (
+        test_backend.convert(
+            SigmaCollection.from_yaml(
+                """
+            title: Test
+            status: test
+            logsource:
+                category: test_category
+                product: test_product
+            detection:
+                sel:
+                    "field|startswith|cased": "va*lue"
+                condition: sel
+        """
+            )
+        )
+        == ['field startswith_cased "va*lue"']
+    )
+
+
 def test_convert_value_str_startswith_expression_not_defined(test_backend, monkeypatch):
     monkeypatch.setattr(test_backend, "startswith_expression", None)
     assert (
@@ -462,6 +505,49 @@ def test_convert_value_str_endswith_further_wildcard_allowed(test_backend, monke
     )
 
 
+def test_convert_value_str_endswith_cased_further_wildcard(test_backend):
+    assert (
+        test_backend.convert(
+            SigmaCollection.from_yaml(
+                """
+            title: Test
+            status: test
+            logsource:
+                category: test_category
+                product: test_product
+            detection:
+                sel:
+                    "field|endswith|cased": "va*lue"
+                condition: sel
+        """
+            )
+        )
+        == ['field casematch "*va*lue"']
+    )
+
+
+def test_convert_value_str_endswith_cased_further_wildcard_allowed(test_backend, monkeypatch):
+    monkeypatch.setattr(test_backend, "case_sensitive_endswith_expression_allow_special", True)
+    assert (
+        test_backend.convert(
+            SigmaCollection.from_yaml(
+                """
+            title: Test
+            status: test
+            logsource:
+                category: test_category
+                product: test_product
+            detection:
+                sel:
+                    "field|endswith|cased": "va*lue"
+                condition: sel
+        """
+            )
+        )
+        == ['field endswith_cased "va*lue"']
+    )
+
+
 def test_convert_value_str_endswith_expression_not_defined(test_backend, monkeypatch):
     monkeypatch.setattr(test_backend, "endswith_expression", None)
     assert (
@@ -568,6 +654,49 @@ def test_convert_value_str_contains_further_wildcard_allowed(test_backend, monke
             )
         )
         == ['mappedA contains "va*lue"']
+    )
+
+
+def test_convert_value_str_contains_cased_further_wildcard(test_backend):
+    assert (
+        test_backend.convert(
+            SigmaCollection.from_yaml(
+                """
+            title: Test
+            status: test
+            logsource:
+                category: test_category
+                product: test_product
+            detection:
+                sel:
+                    "field|contains|cased": "va*lue"
+                condition: sel
+        """
+            )
+        )
+        == ['field casematch "*va*lue*"']
+    )
+
+
+def test_convert_value_str_contains_cased_further_wildcard_allowed(test_backend, monkeypatch):
+    monkeypatch.setattr(test_backend, "case_sensitive_contains_expression_allow_special", True)
+    assert (
+        test_backend.convert(
+            SigmaCollection.from_yaml(
+                """
+            title: Test
+            status: test
+            logsource:
+                category: test_category
+                product: test_product
+            detection:
+                sel:
+                    "field|contains|cased": "va*lue"
+                condition: sel
+        """
+            )
+        )
+        == ['field contains_cased "va*lue"']
     )
 
 

--- a/tests/test_conversion_base.py
+++ b/tests/test_conversion_base.py
@@ -328,6 +328,29 @@ def test_convert_value_str_startswith_further_wildcard(test_backend):
     )
 
 
+def test_convert_value_str_startswith_further_wildcard_allowed(test_backend, monkeypatch):
+    monkeypatch.setattr(test_backend, "startswith_expression_allow_special", True)
+    assert (
+        test_backend.convert(
+            SigmaCollection.from_yaml(
+                """
+            title: Test
+            status: test
+            logsource:
+                category: test_category
+                product: test_product
+            detection:
+                sel:
+                    fieldA|startswith: "va*lue"
+                    field A|startswith: "va*lue"
+                condition: sel
+        """
+            )
+        )
+        == ['mappedA startswith "va*lue" and \'field A\' startswith "va*lue"']
+    )
+
+
 def test_convert_value_str_startswith_expression_not_defined(test_backend, monkeypatch):
     monkeypatch.setattr(test_backend, "startswith_expression", None)
     assert (
@@ -416,6 +439,29 @@ def test_convert_value_str_endswith_further_wildcard(test_backend):
     )
 
 
+def test_convert_value_str_endswith_further_wildcard_allowed(test_backend, monkeypatch):
+    monkeypatch.setattr(test_backend, "endswith_expression_allow_special", True)
+    assert (
+        test_backend.convert(
+            SigmaCollection.from_yaml(
+                """
+            title: Test
+            status: test
+            logsource:
+                category: test_category
+                product: test_product
+            detection:
+                sel:
+                    fieldA|endswith: "va*lue"
+                    field A|endswith: "va*lue"
+                condition: sel
+        """
+            )
+        )
+        == ['mappedA endswith "va*lue" and \'field A\' endswith "va*lue"']
+    )
+
+
 def test_convert_value_str_endswith_expression_not_defined(test_backend, monkeypatch):
     monkeypatch.setattr(test_backend, "endswith_expression", None)
     assert (
@@ -500,6 +546,28 @@ def test_convert_value_str_contains_further_wildcard(test_backend):
             )
         )
         == ['mappedA match "*va*lue*"']
+    )
+
+
+def test_convert_value_str_contains_further_wildcard_allowed(test_backend, monkeypatch):
+    monkeypatch.setattr(test_backend, "contains_expression_allow_special", True)
+    assert (
+        test_backend.convert(
+            SigmaCollection.from_yaml(
+                """
+            title: Test
+            status: test
+            logsource:
+                category: test_category
+                product: test_product
+            detection:
+                sel:
+                    fieldA|contains: "va*lue"
+                condition: sel
+        """
+            )
+        )
+        == ['mappedA contains "va*lue"']
     )
 
 


### PR DESCRIPTION
This pull request adds the ability to use special characters in the startswith, endswith, and contains expressions in the TextQueryBackend. It introduces new variables to control whether special characters are allowed in each expression type.