### PR TITLE
Fix NestedProcessingTransformation

### DIFF
--- a/sigma/processing/transformations.py
+++ b/sigma/processing/transformations.py
@@ -1165,9 +1165,10 @@ class NestedProcessingTransformation(Transformation):
 
     def __post_init__(self):
         from sigma.processing.pipeline import (
-            ProcessingPipeline,
+            ProcessingPipeline, ProcessingItem
         )  # TODO: move to top-level after restructuring code
 
+        self.items = [i if isinstance(i, ProcessingItem) else ProcessingItem.from_dict(i) for i in self.items]
         self._nested_pipeline = ProcessingPipeline(items=self.items)
 
     @classmethod

--- a/sigma/processing/transformations.py
+++ b/sigma/processing/transformations.py
@@ -1165,10 +1165,13 @@ class NestedProcessingTransformation(Transformation):
 
     def __post_init__(self):
         from sigma.processing.pipeline import (
-            ProcessingPipeline, ProcessingItem
+            ProcessingPipeline,
+            ProcessingItem,
         )  # TODO: move to top-level after restructuring code
 
-        self.items = [i if isinstance(i, ProcessingItem) else ProcessingItem.from_dict(i) for i in self.items]
+        self.items = [
+            i if isinstance(i, ProcessingItem) else ProcessingItem.from_dict(i) for i in self.items
+        ]
         self._nested_pipeline = ProcessingPipeline(items=self.items)
 
     @classmethod

--- a/tests/test_processing_transformations.py
+++ b/tests/test_processing_transformations.py
@@ -1752,7 +1752,10 @@ def nested_pipeline_transformation():
     )
 
 
-def test_nested_pipeline_transformation_from_dict(nested_pipeline_transformation):
+def test_nested_pipeline_transformation_from_dict(nested_pipeline_transformation, monkeypatch):
+    monkeypatch.setitem(transformations, "append", TransformationAppend)
+    monkeypatch.setitem(rule_conditions, "true", RuleConditionTrue)
+    monkeypatch.setitem(rule_conditions, "false", RuleConditionFalse)
     assert (
         NestedProcessingTransformation.from_dict(
             {


### PR DESCRIPTION
When using a custom pipeline written in Yaml like so
```python
pipeline_classes = [ecs_windows(), ecs_zeek_corelight()]
pipeline_names = [i.name for i in pipeline_classes if i.name]
ProcessingPipelineResolver.from_pipeline_list(pipeline_classes).resolve(pipeline_names + ['custom_pipeline.yml'])
```
using `NestedProcessingTransformation` like in `custom_pipeline.yml`
```yaml
name: Custom
priority: 100
transformations:
  - type: nest
    items:
      - type: field_name_mapping
        rule_conditions:
          - type: logsource
            service: signinlogs
        mapping:
            ResultType: azure.signinlogs.result_type
```
yields the following error
```
File .../python3.12/site-packages/sigma/processing/transformations.py:1021, in NestedProcessingTransformation.__post_init__(self)
-> 1021 self._nested_pipeline = ProcessingPipeline(items=self.items)

File .../python3.12/site-packages/sigma/processing/pipeline.py:433, in ProcessingPipeline.__post_init__(self)
    432 if not all((isinstance(item, ProcessingItem) for item in self.items)):
--> 433     raise TypeError(
    434         "Each item in a processing pipeline must be a ProcessingItem - don't use processing classes directly!"
    435     )
    436 if not all(
    437     (isinstance(item, QueryPostprocessingItem) for item in self.postprocessing_items)
    438 ):

TypeError: Each item in a processing pipeline must be a ProcessingItem - don't use processing classes directly!
```

So I propose the following fix. Somehow it appears `NestedProcessingTransformation` isn't getting instantiated with its `from_dict` method which would've assured each of its items were of type `ProcessingItem`. Remedying this would be another fix for this issue. There's a chance the way I'm using my custom yaml pipeline is incorrect (`ProcessingPipelineResolver.from_pipeline_list(...).resolve(...)`) in which case please correct me