### PR TITLE
Improve SigmaTransformationError

### DIFF
--- a/sigma/processing/transformations.py
+++ b/sigma/processing/transformations.py
@@ -1117,7 +1117,7 @@ class RuleFailureTransformation(Transformation):
     def apply(
         self, pipeline: "sigma.processing.pipeline.ProcessingPipeline", rule: SigmaRule
     ) -> None:
-        raise SigmaTransformationError(self.message)
+        raise SigmaTransformationError(self.message, source=rule.source)
 
 
 @dataclass
@@ -1131,7 +1131,7 @@ class DetectionItemFailureTransformation(DetectionItemTransformation):
     message: str
 
     def apply_detection_item(self, detection_item: SigmaDetectionItem) -> None:
-        raise SigmaTransformationError(self.message)
+        raise SigmaTransformationError(self.message, source=detection_item.source)
 
 
 @dataclass


### PR DESCRIPTION
include the rule or detection item source since the base exception class `SigmaError` can use it to improve error reporting.