### PR TITLE
Deal with empty string for ignore_case_brackets 

### DIFF
--- a/sigma/processing/transformations.py
+++ b/sigma/processing/transformations.py
@@ -997,6 +997,11 @@ class RegexTransformation(StringValueTransformation):
 
     def apply_string_value(self, field: str, val: SigmaString) -> Optional[SigmaString]:
         regex = ""
+
+        # empty string can not be convert into a simple regex
+        if val == "":
+            return val
+
         for sc in val.s:  # iterate over all SigmaString components (strings and special chars)
             if isinstance(sc, str):  # if component is a string
                 if (

--- a/sigma/processing/transformations.py
+++ b/sigma/processing/transformations.py
@@ -1000,7 +1000,7 @@ class RegexTransformation(StringValueTransformation):
 
         # empty string can not be convert into a simple regex
         if val == "":
-            return val
+            return SigmaRegularExpression("")
 
         for sc in val.s:  # iterate over all SigmaString components (strings and special chars)
             if isinstance(sc, str):  # if component is a string

--- a/tests/test_processing_transformations.py
+++ b/tests/test_processing_transformations.py
@@ -1544,6 +1544,13 @@ def test_regex_transformation_plain_method(dummy_pipeline):
     assert detection_item.value[0] == SigmaRegularExpression("\\\\te\\.st.*va.ue")
 
 
+def test_regex_transformation_empty_string(dummy_pipeline):
+    detection_item = SigmaDetectionItem("field", [], [SigmaString("")])
+    transformation = RegexTransformation(method="plain")
+    transformation.apply_detection_item(detection_item)
+    assert detection_item.value[0] == SigmaRegularExpression("")
+
+
 def test_regex_transformation_case_insensitive_bracket_method(dummy_pipeline):
     detection_item = SigmaDetectionItem("field", [], [SigmaString("\\tE.sT*val?ue")])
     transformation = RegexTransformation(method="ignore_case_brackets")


### PR DESCRIPTION
An empty string must convert to a complex regex .

```yaml
title: test
id: c6c14f6d-e430-4737-bca7-b0fe5496dc07
status: test
date: 2024-11-08
logsource:
    product: windows
    category: pipe_created
detection:
    selection_1:
        Image: null
    selection_2:
        Image: ''
    condition: 1 of selection_*
level: medium
```
```yaml
name: CaseSensitive
priority: 20
transformations:
  - id: field_case
    type: regex
    method: ignore_case_brackets
    field_name_conditions:
      - type: include_fields
        fields: 
          - Image
```

Before
```bash
sigma convert -t lucene rule.yml -p casesensitive.yml
Parsing Sigma rules  [####################################]  100%
(NOT _exists_:Image) OR Image://
sigma convert -t splunk rule.yml -p casesensitive.yml
Parsing Sigma rules  [####################################]  100%
Error: Error while conversion: ORing regular expressions is not yet supported by Splunk backend in rule.yml
```

After
```bash
sigma convert -t lucene rule.yml -p casesensitive.yml
Parsing Sigma rules  [####################################]  100%
(NOT _exists_:Image) OR Image:""

sigma convert -t splunk rule.yml -p casesensitive.yml
Parsing Sigma rules  [####################################]  100%
Image!=* OR Image=""
```