### PR TITLE
Pass Backend Object to Postprocessing Pipeline

### DIFF
--- a/sigma/processing/pipeline.py
+++ b/sigma/processing/pipeline.py
@@ -383,6 +383,7 @@ class QueryPostprocessingItem(ProcessingItemBase):
         if self.match_rule_conditions(
             pipeline, rule
         ):  # apply transformation if conditions match or no condition defined
+            # result = self.transformation.apply(pipeline, rule, query, backend)
             result = self.transformation.apply(pipeline, rule, query, backend)
             return (result, True)
         else:  # just pass rule through

--- a/sigma/processing/pipeline.py
+++ b/sigma/processing/pipeline.py
@@ -235,7 +235,9 @@ class ProcessingItem(ProcessingItemBase):
                 )
 
     def apply(
-        self, pipeline: "ProcessingPipeline", rule: Union[SigmaRule, SigmaCorrelationRule]
+        self,
+        pipeline: "ProcessingPipeline",
+        rule: Union[SigmaRule, SigmaCorrelationRule],
     ) -> bool:
         """
         Matches condition against rule and performs transformation if condition is true or not present.
@@ -372,6 +374,7 @@ class QueryPostprocessingItem(ProcessingItemBase):
         pipeline: "ProcessingPipeline",
         rule: Union[SigmaRule, SigmaCorrelationRule],
         query: str,
+        backend: "Backend" = None,
     ) -> Tuple[str, bool]:
         """
         Matches condition against rule and performs transformation of query if condition is true or not present.
@@ -380,7 +383,7 @@ class QueryPostprocessingItem(ProcessingItemBase):
         if self.match_rule_conditions(
             pipeline, rule
         ):  # apply transformation if conditions match or no condition defined
-            result = self.transformation.apply(pipeline, rule, query)
+            result = self.transformation.apply(pipeline, rule, query, backend)
             return (result, True)
         else:  # just pass rule through
             return (query, False)
@@ -521,10 +524,12 @@ class ProcessingPipeline:
                 self.applied_ids.add(itid)
         return rule
 
-    def postprocess_query(self, rule: Union[SigmaRule, SigmaCorrelationRule], query: Any) -> Any:
+    def postprocess_query(
+        self, rule: Union[SigmaRule, SigmaCorrelationRule], query: Any, backend: Any = None
+    ) -> Any:
         """Post-process queries with postprocessing_items."""
         for item in self.postprocessing_items:
-            query, applied = item.apply(self, rule, query)
+            query, applied = item.apply(self, rule, query, backend)
             if applied and (itid := item.identifier):
                 self.applied_ids.add(itid)
         return query

--- a/sigma/processing/postprocessing.py
+++ b/sigma/processing/postprocessing.py
@@ -21,7 +21,10 @@ class QueryPostprocessingTransformation(Transformation):
 
     @abstractmethod
     def apply(
-        self, pipeline: "sigma.processing.pipeline.ProcessingPipeline", rule: SigmaRule, query: Any
+        self,
+        pipeline: "sigma.processing.pipeline.ProcessingPipeline",
+        rule: SigmaRule,
+        query: Any,
     ) -> Any:
         """Applies post-processing transformation to arbitrary typed query.
 
@@ -49,7 +52,11 @@ class EmbedQueryTransformation(QueryPostprocessingTransformation):
         self.suffix = self.suffix or ""
 
     def apply(
-        self, pipeline: "sigma.processing.pipeline.ProcessingPipeline", rule: SigmaRule, query: str
+        self,
+        pipeline: "sigma.processing.pipeline.ProcessingPipeline",
+        rule: SigmaRule,
+        query: str,
+        backend: Any = None,
     ) -> str:
         super().apply(pipeline, rule, query)
         return self.prefix + query + self.suffix
@@ -71,7 +78,11 @@ class QuerySimpleTemplateTransformation(QueryPostprocessingTransformation):
     template: str
 
     def apply(
-        self, pipeline: "sigma.processing.pipeline.ProcessingPipeline", rule: SigmaRule, query: str
+        self,
+        pipeline: "sigma.processing.pipeline.ProcessingPipeline",
+        rule: SigmaRule,
+        query: str,
+        backend: Any = None,
     ) -> str:
         return self.template.format(
             query=query,
@@ -96,9 +107,13 @@ class QueryTemplateTransformation(QueryPostprocessingTransformation, TemplateBas
     """
 
     def apply(
-        self, pipeline: "sigma.processing.pipeline.ProcessingPipeline", rule: SigmaRule, query: str
+        self,
+        pipeline: "sigma.processing.pipeline.ProcessingPipeline",
+        rule: SigmaRule,
+        query: str,
+        backend: Any,
     ) -> str:
-        return self.j2template.render(query=query, rule=rule, pipeline=pipeline)
+        return self.j2template.render(query=query, rule=rule, pipeline=pipeline, backend=backend)
 
 
 @dataclass
@@ -124,7 +139,11 @@ class EmbedQueryInJSONTransformation(QueryPostprocessingTransformation):
         self.parsed_json = json.loads(self.json_template)
 
     def apply(
-        self, pipeline: "sigma.processing.pipeline.ProcessingPipeline", rule: SigmaRule, query: str
+        self,
+        pipeline: "sigma.processing.pipeline.ProcessingPipeline",
+        rule: SigmaRule,
+        query: str,
+        backend: Any = None,
     ):
         super().apply(pipeline, rule, query)
         return json.dumps(self._replace_placeholder(self.parsed_json, query))
@@ -141,7 +160,11 @@ class ReplaceQueryTransformation(QueryPostprocessingTransformation):
         self.re = re.compile(self.pattern)
 
     def apply(
-        self, pipeline: "sigma.processing.pipeline.ProcessingPipeline", rule: SigmaRule, query: str
+        self,
+        pipeline: "sigma.processing.pipeline.ProcessingPipeline",
+        rule: SigmaRule,
+        query: str,
+        backend: Any = None,
     ):
         super().apply(pipeline, rule, query)
         return self.re.sub(self.replacement, query)
@@ -178,7 +201,11 @@ class NestedQueryPostprocessingTransformation(QueryPostprocessingTransformation)
             )
 
     def apply(
-        self, pipeline: "sigma.processing.pipeline.ProcessingPipeline", rule: SigmaRule, query: Any
+        self,
+        pipeline: "sigma.processing.pipeline.ProcessingPipeline",
+        rule: SigmaRule,
+        query: Any,
+        backend: Any = None,
     ) -> Any:
         super().apply(pipeline, rule, query)
         query = self._nested_pipeline.postprocess_query(rule, query)

--- a/tests/test_postprocessing_transformations.py
+++ b/tests/test_postprocessing_transformations.py
@@ -11,6 +11,7 @@ from sigma.processing.postprocessing import (
 )
 from sigma.rule import SigmaRule
 from .test_processing_transformations import dummy_pipeline, sigma_rule
+from .test_backend_identifier import DummyBackend
 
 
 def test_embed_query_transformation(dummy_pipeline, sigma_rule):
@@ -53,8 +54,9 @@ state = {{ pipeline.state.test }}
     """
     )
     dummy_pipeline.state["test"] = "teststate"
+
     assert (
-        transformation.apply(dummy_pipeline, sigma_rule, 'field="value"')
+        transformation.apply(dummy_pipeline, sigma_rule, 'field="value"', DummyBackend)
         == """
 title = Test
 query = field="value"

--- a/tests/test_postprocessing_transformations.py
+++ b/tests/test_postprocessing_transformations.py
@@ -51,6 +51,7 @@ def test_query_template_transformation(dummy_pipeline: ProcessingPipeline, sigma
 title = {{ rule.title }}
 query = {{ query }}
 state = {{ pipeline.state.test }}
+backend_id = {{ backend.identifier }}
     """
     )
     dummy_pipeline.state["test"] = "teststate"
@@ -61,6 +62,7 @@ state = {{ pipeline.state.test }}
 title = Test
 query = field="value"
 state = teststate
+backend_id = dummy
     """
     )
 


### PR DESCRIPTION
Hi everyone, 

following my Pull Request to add a postprocessing template for the siem_rule_ndjson format for the Elasticsearch backend (https://github.com/SigmaHQ/pySigma-backend-elasticsearch/pull/94) I want to propose some minor changes here to enable the `QueryTemplateTransformation` to access variables that are managed by the backend directly. For this, the backend object is passed to the Jinja render functionality. I´ve seen on Discord that this functionality was also discussed there. 

**How to use the new Functionality:**
In a postprocessing pipeline when using the `QueryTemplateTransformation`, variables managed by the backend can be accessed for example by `{{ backend.variable1 }}`.

One unit test was adjusted to check if the access is working correctly.

The backend object is handed over to all postprocessing transformations inside the `apply` function, however currently only `QueryTemplateTransformation` uses the backend reference whereas the rest of the transformations do not use it because I thought that this might be the most common use case. Do you think that the other transformations should also implement some handling with this new reference? 

Thank you for the great project and feel free to comment and edit :)