### PR TITLE
Check invalid pipeline keys

### DIFF
--- a/sigma/processing/pipeline.py
+++ b/sigma/processing/pipeline.py
@@ -488,6 +488,24 @@ class ProcessingPipeline:
     @classmethod
     def from_dict(cls, d: dict) -> "ProcessingPipeline":
         """Instantiate processing pipeline from a parsed processing item description."""
+
+        custom_keys = [
+            k
+            for k in d.keys()
+            if k
+            not in (
+                "vars",
+                "transformations",
+                "postprocessing",
+                "finalizers",
+                "priority",
+                "name",
+                "allowed_backends",
+            )
+        ]
+        if custom_keys:
+            raise SigmaConfigurationError(f"Unkown keys {custom_keys}")
+
         vars = d.get("vars", dict())  # default: no variables
 
         items = d.get("transformations", list())  # default: no transformation

--- a/tests/test_processing_pipeline.py
+++ b/tests/test_processing_pipeline.py
@@ -5,6 +5,7 @@ from sigma.processing.pipeline import (
     ProcessingPipeline,
     ProcessingItem,
     QueryPostprocessingItem,
+    SigmaPipelineParsingError,
 )
 from sigma.processing.transformations import transformations
 from sigma.processing.conditions import (
@@ -603,6 +604,35 @@ def test_processingpipeline_fromyaml(
             allowed_backends={"test-a", "test-b"},
         )
     )
+
+
+def test_processingpipeline_fromyaml_invalid(
+    processing_item_dict, processing_item, postprocessing_item, processing_pipeline_vars
+):
+    with pytest.raises(
+        SigmaPipelineParsingError, match="Error in parsing of a Sigma processing pipeline"
+    ):
+        ProcessingPipeline.from_yaml(
+            """
+                {not a yaml
+            """
+        )
+
+
+def test_processingpipeline_fromyaml_unknown(
+    processing_item_dict, processing_item, postprocessing_item, processing_pipeline_vars
+):
+    with pytest.raises(SigmaConfigurationError, match="Unkown keys \['transformation'\]"):
+        ProcessingPipeline.from_yaml(
+            """
+        name: unknown
+        priority: 10
+        transformation:
+        - id: test
+          type: test
+          method: test
+            """
+        )
 
 
 def test_processingpipeline_fromdict_error(processing_item_dict_with_error):


### PR DESCRIPTION
As it's easy to make a typo error but since there's no feedback, it's hard to find it.

Add a test validation for invalid yaml in the same time