### PR TITLE
#309 Support for snake_case transformation on a field.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 docs/_build
 coverage.xml
 .python-version
+.idea

--- a/sigma/processing/transformations/values.py
+++ b/sigma/processing/transformations/values.py
@@ -374,10 +374,10 @@ class ConvertTypeTransformation(ValueTransformation):
 @dataclass
 class CaseTransformation(StringValueTransformation):
     """
-    Transform a string value to a lower or upper case.
+    Transform a string value to a lower or upper or snake case.
     """
 
-    method: Literal["lower", "upper"] = "lower"
+    method: Literal["lower", "upper", "snake_case"] = "lower"
 
     def __post_init__(self):
         if self.method not in self.__annotations__["method"].__args__:
@@ -386,7 +386,9 @@ class CaseTransformation(StringValueTransformation):
 
     def apply_string_value(self, field: str, val: SigmaString) -> Optional[SigmaString]:
 
-        if self.method == "lower":
+        if self.method == "snake_case":
+            return val.snake_case()
+        elif self.method == "lower":
             return val.lower()
         else:
             return val.upper()

--- a/sigma/types.py
+++ b/sigma/types.py
@@ -589,6 +589,9 @@ class SigmaString(SigmaType):
     def lower(self) -> "SigmaString":
         return self.map_parts(str.lower, lambda x: isinstance(x, str))
 
+    def snake_case(self) -> "SigmaString":
+        return self.map_parts(lambda x: re.sub(r'(?<!^)(?=[A-Z])', '_', x).lower(), lambda x: isinstance(x, str))
+
 
 class SigmaCasedString(SigmaString):
     """Case-sensitive string matching."""

--- a/sigma/types.py
+++ b/sigma/types.py
@@ -590,7 +590,9 @@ class SigmaString(SigmaType):
         return self.map_parts(str.lower, lambda x: isinstance(x, str))
 
     def snake_case(self) -> "SigmaString":
-        return self.map_parts(lambda x: re.sub(r'(?<!^)(?=[A-Z])', '_', x).lower(), lambda x: isinstance(x, str))
+        return self.map_parts(
+            lambda x: re.sub(r"(?<!^)(?=[A-Z])", "_", x).lower(), lambda x: isinstance(x, str)
+        )
 
 
 class SigmaCasedString(SigmaString):

--- a/tests/test_processing_transformations.py
+++ b/tests/test_processing_transformations.py
@@ -2055,6 +2055,27 @@ def test_case_transformation_special(dummy_pipeline):
     )
 
 
+def test_case_transformation_snake_case_from_camel_case(dummy_pipeline):
+    detection_item = SigmaDetectionItem("field", [], [SigmaString("abcDef")])
+    transformation = CaseTransformation(method="snake_case")
+    transformation.apply_detection_item(detection_item)
+    assert detection_item.value[0] == SigmaString("abc_def")
+
+
+def test_case_transformation_snake_case_from_pascal_case(dummy_pipeline):
+    detection_item = SigmaDetectionItem("field", [], [SigmaString("AbcDef")])
+    transformation = CaseTransformation(method="snake_case")
+    transformation.apply_detection_item(detection_item)
+    assert detection_item.value[0] == SigmaString("abc_def")
+
+
+def test_case_transformation_snake_case_from_snake_case(dummy_pipeline):
+    detection_item = SigmaDetectionItem("field", [], [SigmaString("abc_def")])
+    transformation = CaseTransformation(method="snake_case")
+    transformation.apply_detection_item(detection_item)
+    assert detection_item.value[0] == SigmaString("abc_def")
+
+
 def test_case_transformation_error():
     with pytest.raises(
         SigmaConfigurationError, match="Invalid method 'SnakeCase' for CaseTransformation."


### PR DESCRIPTION
### Description
This PR enhances the existing CaseTransformation to convert strings from various naming conventions (e.g., camelCase, PascalCase) to snake_case (Issue [309](https://github.com/SigmaHQ/pySigma/issues/309)).

### Key Features

1. Conversion from camelCase:
Identifies and converts camelCase strings to snake_case.
Example: camelCaseExample → camel_case_example.

2. Conversion from PascalCase:
Supports PascalCase string conversion to snake_case.
Example: PascalCaseExample → pascal_case_example.
3. Handles Already Snake Case Strings:
Detects and returns snake_case strings without modifications.








