### PR TITLE
Add MatchValueCondition for exact value matching

### DIFF
--- a/sigma/processing/conditions/__init__.py
+++ b/sigma/processing/conditions/__init__.py
@@ -28,6 +28,7 @@ from sigma.processing.conditions.values import (
     ContainsWildcardCondition,
     IsNullCondition,
     MatchStringCondition,
+    MatchValueCondition,
 )
 
 
@@ -44,6 +45,7 @@ rule_conditions: Dict[str, RuleProcessingCondition] = {
 }
 detection_item_conditions: Dict[str, DetectionItemProcessingCondition] = {
     "match_string": MatchStringCondition,
+    "match_value": MatchValueCondition,
     "contains_wildcard": ContainsWildcardCondition,
     "is_null": IsNullCondition,
     "processing_item_applied": DetectionItemProcessingItemAppliedCondition,

--- a/sigma/processing/conditions/values.py
+++ b/sigma/processing/conditions/values.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Union
 
 import sigma
 from sigma.processing.conditions.base import (
@@ -39,6 +40,18 @@ class MatchStringCondition(ValueProcessingCondition):
             return not result
         else:
             return result
+
+
+@dataclass
+class MatchValueCondition(ValueProcessingCondition):
+    """
+    Exact match of a value with an arbitrary Sigma type.
+    """
+
+    value: Union[str, int, float, bool]
+
+    def match_value(self, value: SigmaType) -> bool:
+        return value == self.value
 
 
 class ContainsWildcardCondition(ValueProcessingCondition):

--- a/sigma/types.py
+++ b/sigma/types.py
@@ -648,6 +648,12 @@ class SigmaBool(SigmaType):
     def __bool__(self):
         return self.boolean
 
+    def __eq__(self, other: Union["SigmaBool", bool]) -> bool:
+        if isinstance(other, bool):
+            return self.boolean == other
+        else:
+            return self.boolean == other.boolean
+
 
 class SigmaRegularExpressionFlag(Enum):
     IGNORECASE = auto()

--- a/tests/test_processing_conditions.py
+++ b/tests/test_processing_conditions.py
@@ -2,7 +2,8 @@ import inspect
 from typing import cast
 from sigma.collection import SigmaCollection
 from sigma.correlations import SigmaCorrelationRule
-from sigma.types import SigmaNull, SigmaNumber, SigmaString
+from sigma.processing.conditions.values import MatchValueCondition
+from sigma.types import SigmaBool, SigmaNull, SigmaNumber, SigmaString
 from sigma import processing
 from sigma.exceptions import (
     SigmaConfigurationError,
@@ -420,9 +421,45 @@ def test_match_string_condition_error_mode():
         MatchStringCondition(pattern="x", cond="test")
 
 
-def test_match_string_condition_error_mode():
+def test_match_string_condition_error_pattern():
     with pytest.raises(SigmaRegularExpressionError, match="is invalid"):
         MatchStringCondition(pattern="*", cond="any")
+
+
+def test_match_value_condition_str():
+    assert MatchValueCondition(value="test", cond="any").match(
+        SigmaDetectionItem("field", [], [SigmaString("test")])
+    )
+
+
+def test_match_value_condition_str_nomatch():
+    assert not MatchValueCondition(value="test", cond="any").match(
+        SigmaDetectionItem("field", [], [SigmaString("other")])
+    )
+
+
+def test_match_value_condition_number():
+    assert MatchValueCondition(value=123, cond="any").match(
+        SigmaDetectionItem("field", [], [SigmaNumber(123)])
+    )
+
+
+def test_match_value_condition_number_nomatch():
+    assert not MatchValueCondition(value=123, cond="any").match(
+        SigmaDetectionItem("field", [], [SigmaNumber(124)])
+    )
+
+
+def test_match_value_condition_bool():
+    assert MatchValueCondition(value=True, cond="any").match(
+        SigmaDetectionItem("field", [], [SigmaBool(True)])
+    )
+
+
+def test_match_value_condition_bool_nomatch():
+    assert not MatchValueCondition(value=True, cond="any").match(
+        SigmaDetectionItem("field", [], [SigmaBool(False)])
+    )
 
 
 def test_contains_wildcard_condition_match():


### PR DESCRIPTION
Introduce MatchValueCondition to enable exact matching of arbitrary types, enhancing the condition evaluation capabilities. Include tests for string, number, and boolean matches.