### PR TITLE
Fix: Handle None case in field_name_prefix_mapping

### DIFF
--- a/sigma/processing/transformations/fields.py
+++ b/sigma/processing/transformations/fields.py
@@ -55,6 +55,9 @@ class FieldPrefixMappingTransformation(FieldMappingTransformation):
     """Map a field name prefix to one or multiple different prefixes."""
 
     def get_mapping(self, field: str) -> Union[None, str, List[str]]:
+        if field is None:
+            return None
+        
         for src, dest in self.mapping.items():
             if field.startswith(src):  # found matching prefix
                 if isinstance(dest, str):

--- a/sigma/processing/transformations/fields.py
+++ b/sigma/processing/transformations/fields.py
@@ -57,7 +57,7 @@ class FieldPrefixMappingTransformation(FieldMappingTransformation):
     def get_mapping(self, field: str) -> Union[None, str, List[str]]:
         if field is None:
             return None
-        
+
         for src, dest in self.mapping.items():
             if field.startswith(src):  # found matching prefix
                 if isinstance(dest, str):

--- a/tests/test_processing_transformations.py
+++ b/tests/test_processing_transformations.py
@@ -493,6 +493,26 @@ def test_field_prefix_mapping(dummy_pipeline, field_prefix_mapping_transformatio
     }
 
 
+def test_field_prefix_mapping_keyword_detection(
+    dummy_pipeline, keyword_sigma_rule, field_prefix_mapping_transformation
+):
+    field_prefix_mapping_transformation.set_pipeline(dummy_pipeline)
+    field_prefix_mapping_transformation.apply(keyword_sigma_rule)
+    assert keyword_sigma_rule.detection.detections["test"] == SigmaDetection(
+        [
+            SigmaDetectionItem(
+                None,
+                [],
+                [
+                    SigmaString("value1"),
+                    SigmaString("value2"),
+                    SigmaString("value3"),
+                ],
+            ),
+        ]
+    )
+
+
 def test_field_prefix_mapping_correlation_rule(
     dummy_pipeline, sigma_correlation_rule, field_prefix_mapping_transformation
 ):


### PR DESCRIPTION
This pull request fixes an issue in the `FieldPrefixMappingTransformation` class where the get_mapping method did not handle cases where the `field` parameter is `None`.