### PR TITLE
Implement timestamp part modifiers for use in backends.

### DIFF
--- a/sigma/conversion/base.py
+++ b/sigma/conversion/base.py
@@ -52,7 +52,7 @@ from sigma.types import (
     SigmaNull,
     SigmaQueryExpression,
     SigmaCIDRExpression,
-    SpecialChars,
+    SpecialChars, SigmaTimestampPart, TimestampPart,
 )
 from sigma.conversion.state import ConversionState
 
@@ -336,6 +336,12 @@ class Backend(ABC):
         """Conversion of field = number value expressions"""
 
     @abstractmethod
+    def convert_condition_field_eq_val_timestamp_part(
+        self, cond: ConditionFieldEqualsValueExpression, state: ConversionState
+    ) -> Any:
+        """Conversion of field = timestamp part value expressions"""
+
+    @abstractmethod
     def convert_condition_field_eq_val_bool(
         self, cond: ConditionFieldEqualsValueExpression, state: ConversionState
     ) -> Any:
@@ -433,6 +439,8 @@ class Backend(ABC):
             return self.convert_condition_field_eq_val_str_case_sensitive(cond, state)
         elif isinstance(cond.value, SigmaString):
             return self.convert_condition_field_eq_val_str(cond, state)
+        elif isinstance(cond.value, SigmaTimestampPart):
+            return self.convert_condition_field_eq_val_timestamp_part(cond, state)
         elif isinstance(cond.value, SigmaNumber):
             return self.convert_condition_field_eq_val_num(cond, state)
         elif isinstance(cond.value, SigmaBool):
@@ -472,6 +480,12 @@ class Backend(ABC):
         """Conversion of number-only conditions."""
 
     @abstractmethod
+    def convert_condition_val_timestamp_part(
+        self, cond: ConditionValueExpression, state: ConversionState
+    ) -> Any:
+        """Conversion of timestamp part-only conditions."""
+
+    @abstractmethod
     def convert_condition_val_re(
         self, cond: ConditionValueExpression, state: ConversionState
     ) -> Any:
@@ -487,6 +501,8 @@ class Backend(ABC):
         """Conversion of value-only conditions."""
         if isinstance(cond.value, SigmaString):
             return self.convert_condition_val_str(cond, state)
+        elif isinstance(cond.value, SigmaTimestampPart):
+            return self.convert_condition_val_timestamp_part(cond, state)
         elif isinstance(cond.value, SigmaNumber):
             return self.convert_condition_val_num(cond, state)
         elif isinstance(cond.value, SigmaBool):
@@ -894,6 +910,12 @@ class TextQueryBackend(Backend):
     field_equals_field_startswith_expression: ClassVar[Optional[str]] = None
     field_equals_field_endswith_expression: ClassVar[Optional[str]] = None
     field_equals_field_contains_expression: ClassVar[Optional[str]] = None
+
+    field_timestamp_part_expression: ClassVar[Optional[str]] = None
+    """Expression for timestamp part modifiers like |minute, |day, etc."""
+
+    timestamp_part_mapping: ClassVar[Optional[dict[TimestampPart, str]]] = None
+    """Mapping to map a TimestampPart enum value to it's string representation of the target SIEM. Example value: '%M' for minute."""
 
     field_equals_field_escaping_quoting: Tuple[bool, bool] = (
         True,
@@ -1537,6 +1559,20 @@ class TextQueryBackend(Backend):
                 "Field equals numeric value expressions are not supported by the backend."
             )
 
+    def convert_condition_field_eq_val_timestamp_part(
+            self, cond: ConditionFieldEqualsValueExpression, state: ConversionState
+    ) -> Any:
+        """Conversion of field = timestamp part value expressions"""
+        try:
+            if isinstance(cond.value, SigmaTimestampPart):
+                return self.field_timestamp_part_expression.format(field=self.escape_and_quote_field(cond.field), timestamp_part=self.timestamp_part_mapping[cond.value.timestamp_part])  + self.eq_token + str(cond.value)
+            else:
+                raise ValueError(f"Wrong type for cond.value. Expected SigmaTimestampPart, got {type(cond.value)}")
+        except TypeError as e:  # pragma: no cover
+            raise NotImplementedError(
+                f"Field equals numeric value expressions are not supported by the backend: {e}"
+            )
+
     def convert_condition_field_eq_val_bool(
         self, cond: ConditionFieldEqualsValueExpression, state: ConversionState
     ) -> Union[str, DeferredQueryExpression]:
@@ -1735,6 +1771,12 @@ class TextQueryBackend(Backend):
     ) -> Union[str, DeferredQueryExpression]:
         """Conversion of value-only numbers."""
         return self.unbound_value_num_expression.format(value=cond.value)
+
+    def convert_condition_val_timestamp_part(
+        self, cond: ConditionValueExpression, state: ConversionState
+    ) -> Union[str, DeferredQueryExpression]:
+        """Conversion of timestamp part numbers."""
+        return self.field_timestamp_part_expression.format(field=self.escape_and_quote_field(cond.field), timestamp_part=self.timestamp_part_mapping[cond.value.timestamp_part])  + self.eq_token + str(cond.value)
 
     def convert_condition_val_re(
         self, cond: ConditionValueExpression, state: ConversionState

--- a/sigma/conversion/base.py
+++ b/sigma/conversion/base.py
@@ -52,7 +52,9 @@ from sigma.types import (
     SigmaNull,
     SigmaQueryExpression,
     SigmaCIDRExpression,
-    SpecialChars, SigmaTimestampPart, TimestampPart,
+    SpecialChars,
+    SigmaTimestampPart,
+    TimestampPart,
 )
 from sigma.conversion.state import ConversionState
 
@@ -1560,14 +1562,23 @@ class TextQueryBackend(Backend):
             )
 
     def convert_condition_field_eq_val_timestamp_part(
-            self, cond: ConditionFieldEqualsValueExpression, state: ConversionState
+        self, cond: ConditionFieldEqualsValueExpression, state: ConversionState
     ) -> Any:
         """Conversion of field = timestamp part value expressions"""
         try:
             if isinstance(cond.value, SigmaTimestampPart):
-                return self.field_timestamp_part_expression.format(field=self.escape_and_quote_field(cond.field), timestamp_part=self.timestamp_part_mapping[cond.value.timestamp_part])  + self.eq_token + str(cond.value)
+                return (
+                    self.field_timestamp_part_expression.format(
+                        field=self.escape_and_quote_field(cond.field),
+                        timestamp_part=self.timestamp_part_mapping[cond.value.timestamp_part],
+                    )
+                    + self.eq_token
+                    + str(cond.value)
+                )
             else:
-                raise ValueError(f"Wrong type for cond.value. Expected SigmaTimestampPart, got {type(cond.value)}")
+                raise ValueError(
+                    f"Wrong type for cond.value. Expected SigmaTimestampPart, got {type(cond.value)}"
+                )
         except TypeError as e:  # pragma: no cover
             raise NotImplementedError(
                 f"Field equals numeric value expressions are not supported by the backend: {e}"
@@ -1776,7 +1787,14 @@ class TextQueryBackend(Backend):
         self, cond: ConditionValueExpression, state: ConversionState
     ) -> Union[str, DeferredQueryExpression]:
         """Conversion of timestamp part numbers."""
-        return self.field_timestamp_part_expression.format(field=self.escape_and_quote_field(cond.field), timestamp_part=self.timestamp_part_mapping[cond.value.timestamp_part])  + self.eq_token + str(cond.value)
+        return (
+            self.field_timestamp_part_expression.format(
+                field=self.escape_and_quote_field(cond.field),
+                timestamp_part=self.timestamp_part_mapping[cond.value.timestamp_part],
+            )
+            + self.eq_token
+            + str(cond.value)
+        )
 
     def convert_condition_val_re(
         self, cond: ConditionValueExpression, state: ConversionState

--- a/sigma/modifiers.py
+++ b/sigma/modifiers.py
@@ -29,7 +29,9 @@ from sigma.types import (
     SpecialChars,
     SigmaRegularExpression,
     SigmaCompareExpression,
-    SigmaCIDRExpression, SigmaTimestampPart, TimestampPart,
+    SigmaCIDRExpression,
+    SigmaTimestampPart,
+    TimestampPart,
 )
 from sigma.conditions import ConditionAND
 from sigma.exceptions import SigmaRuleLocation, SigmaTypeError, SigmaValueError

--- a/sigma/modifiers.py
+++ b/sigma/modifiers.py
@@ -29,7 +29,7 @@ from sigma.types import (
     SpecialChars,
     SigmaRegularExpression,
     SigmaCompareExpression,
-    SigmaCIDRExpression,
+    SigmaCIDRExpression, SigmaTimestampPart, TimestampPart,
 )
 from sigma.conditions import ConditionAND
 from sigma.exceptions import SigmaRuleLocation, SigmaTypeError, SigmaValueError
@@ -393,6 +393,60 @@ class SigmaExpandModifier(SigmaValueModifier):
         return val.insert_placeholders()
 
 
+class SigmaTimestampMinuteModifier(SigmaValueModifier):
+    """
+    Modifier that parses the field as a datetime/timestamp and transforms it to the minute number. Between 0 and 59.
+    """
+
+    def modify(self, val: SigmaNumber) -> SigmaTimestampPart:
+        return SigmaTimestampPart(TimestampPart.MINUTE, val.number)
+
+
+class SigmaTimestampHourModifier(SigmaValueModifier):
+    """
+    Modifier that parses the field as a datetime/timestamp and transforms it to the hour number. Between 0 and 23.
+    """
+
+    def modify(self, val: SigmaNumber) -> SigmaTimestampPart:
+        return SigmaTimestampPart(TimestampPart.HOUR, val.number)
+
+
+class SigmaTimestampDayModifier(SigmaValueModifier):
+    """
+    Modifier that parses the field as a datetime/timestamp and transforms it to the day of the month number. Between 1 and 31.
+    """
+
+    def modify(self, val: SigmaNumber) -> SigmaTimestampPart:
+        return SigmaTimestampPart(TimestampPart.DAY, val.number)
+
+
+class SigmaTimestampWeekModifier(SigmaValueModifier):
+    """
+    Modifier that parses the field as a datetime/timestamp and transforms it to the week of the year number. Between 1 and 52.
+    """
+
+    def modify(self, val: SigmaNumber) -> SigmaTimestampPart:
+        return SigmaTimestampPart(TimestampPart.WEEK, val.number)
+
+
+class SigmaTimestampMonthModifier(SigmaValueModifier):
+    """
+    Modifier that parses the field as a datetime/timestamp and transforms it to the month of the year number. Between 1 and 12.
+    """
+
+    def modify(self, val: SigmaNumber) -> SigmaTimestampPart:
+        return SigmaTimestampPart(TimestampPart.MONTH, val.number)
+
+
+class SigmaTimestampYearModifier(SigmaValueModifier):
+    """
+    Modifier that parses the field as a datetime/timestamp and transforms it to the year number.
+    """
+
+    def modify(self, val: SigmaNumber) -> SigmaTimestampPart:
+        return SigmaTimestampPart(TimestampPart.YEAR, val.number)
+
+
 # Mapping from modifier identifier strings to modifier classes
 modifier_mapping: Dict[str, Type[SigmaModifier]] = {
     "all": SigmaAllModifier,
@@ -401,6 +455,7 @@ modifier_mapping: Dict[str, Type[SigmaModifier]] = {
     "cased": SigmaCaseSensitiveModifier,
     "cidr": SigmaCIDRModifier,
     "contains": SigmaContainsModifier,
+    "day": SigmaTimestampDayModifier,
     "dotall": SigmaRegularExpressionDotAllFlagModifier,
     "endswith": SigmaEndswithModifier,
     "exists": SigmaExistsModifier,
@@ -408,17 +463,22 @@ modifier_mapping: Dict[str, Type[SigmaModifier]] = {
     "fieldref": SigmaFieldReferenceModifier,
     "gt": SigmaGreaterThanModifier,
     "gte": SigmaGreaterThanEqualModifier,
+    "hour": SigmaTimestampHourModifier,
     "i": SigmaRegularExpressionIgnoreCaseFlagModifier,
     "ignorecase": SigmaRegularExpressionIgnoreCaseFlagModifier,
     "lt": SigmaLessThanModifier,
     "lte": SigmaLessThanEqualModifier,
     "m": SigmaRegularExpressionMultilineFlagModifier,
+    "minute": SigmaTimestampMinuteModifier,
+    "month": SigmaTimestampMonthModifier,
     "multiline": SigmaRegularExpressionMultilineFlagModifier,
     "re": SigmaRegularExpressionModifier,
     "s": SigmaRegularExpressionDotAllFlagModifier,
     "startswith": SigmaStartswithModifier,
+    "week": SigmaTimestampWeekModifier,
     "wide": SigmaWideModifier,
     "windash": SigmaWindowsDashModifier,
+    "year": SigmaTimestampYearModifier,
 }
 
 # Mapping from modifier class to identifier

--- a/sigma/types.py
+++ b/sigma/types.py
@@ -45,6 +45,7 @@ class TimestampPart(Enum):
     MONTH = auto()
     YEAR = auto()
 
+
 @dataclass
 class Placeholder:
     """

--- a/sigma/types.py
+++ b/sigma/types.py
@@ -35,6 +35,16 @@ class SpecialChars(Enum):
     WILDCARD_SINGLE = auto()
 
 
+class TimestampPart(Enum):
+    """Enumeration of supported datetime parts for a SigmaTimestamp object"""
+
+    MINUTE = auto()
+    HOUR = auto()
+    DAY = auto()
+    WEEK = auto()
+    MONTH = auto()
+    YEAR = auto()
+
 @dataclass
 class Placeholder:
     """
@@ -634,6 +644,15 @@ class SigmaNumber(SigmaType):
             raise NotImplementedError(
                 "SigmaNumber can only be compared with a number or another SigmaNumber"
             )
+
+
+class SigmaTimestampPart(SigmaNumber):
+
+    timestamp_part: TimestampPart
+
+    def __init__(self, timestamp_part: TimestampPart, number: int):
+        self.timestamp_part = timestamp_part
+        super().__init__(number)
 
 
 @dataclass

--- a/tests/test_modifiers.py
+++ b/tests/test_modifiers.py
@@ -22,7 +22,8 @@ from sigma.modifiers import (
     SigmaGreaterThanModifier,
     SigmaGreaterThanEqualModifier,
     SigmaExpandModifier,
-    SigmaWindowsDashModifier,
+    SigmaWindowsDashModifier, SigmaTimestampMinuteModifier, SigmaTimestampHourModifier, SigmaTimestampDayModifier,
+    SigmaTimestampWeekModifier, SigmaTimestampMonthModifier, SigmaTimestampYearModifier,
 )
 from sigma.rule import SigmaDetectionItem
 from sigma.types import (
@@ -39,7 +40,7 @@ from sigma.types import (
     SigmaRegularExpression,
     SigmaCompareExpression,
     SigmaCIDRExpression,
-    SpecialChars,
+    SpecialChars, TimestampPart, SigmaTimestampPart,
 )
 from sigma.conditions import ConditionAND
 from sigma.exceptions import SigmaRuleLocation, SigmaTypeError, SigmaValueError
@@ -502,3 +503,39 @@ def test_cidr_invalid(dummy_detection_item):
         SigmaCIDRModifier(dummy_detection_item, [], SigmaRuleLocation("test.yml")).modify(
             SigmaString("192.168.1.1/24")
         )
+
+
+def test_timestamp_minute_modifier(dummy_detection_item):
+    assert SigmaTimestampMinuteModifier(dummy_detection_item, []).modify(
+        SigmaNumber(123)
+    ) == SigmaTimestampPart(TimestampPart.MINUTE, 123)
+
+
+def test_timestamp_hour_modifier(dummy_detection_item):
+    assert SigmaTimestampHourModifier(dummy_detection_item, []).modify(
+        SigmaNumber(123)
+    ) == SigmaTimestampPart(TimestampPart.HOUR, 123)
+
+
+def test_timestamp_day_modifier(dummy_detection_item):
+    assert SigmaTimestampDayModifier(dummy_detection_item, []).modify(
+        SigmaNumber(123)
+    ) == SigmaTimestampPart(TimestampPart.DAY, 123)
+
+
+def test_timestamp_week_modifier(dummy_detection_item):
+    assert SigmaTimestampWeekModifier(dummy_detection_item, []).modify(
+        SigmaNumber(123)
+    ) == SigmaTimestampPart(TimestampPart.WEEK, 123)
+
+
+def test_timestamp_month_modifier(dummy_detection_item):
+    assert SigmaTimestampMonthModifier(dummy_detection_item, []).modify(
+        SigmaNumber(123)
+    ) == SigmaTimestampPart(TimestampPart.MONTH, 123)
+
+
+def test_timestamp_year_modifier(dummy_detection_item):
+    assert SigmaTimestampYearModifier(dummy_detection_item, []).modify(
+        SigmaNumber(123)
+    ) == SigmaTimestampPart(TimestampPart.YEAR, 123)

--- a/tests/test_modifiers.py
+++ b/tests/test_modifiers.py
@@ -22,8 +22,13 @@ from sigma.modifiers import (
     SigmaGreaterThanModifier,
     SigmaGreaterThanEqualModifier,
     SigmaExpandModifier,
-    SigmaWindowsDashModifier, SigmaTimestampMinuteModifier, SigmaTimestampHourModifier, SigmaTimestampDayModifier,
-    SigmaTimestampWeekModifier, SigmaTimestampMonthModifier, SigmaTimestampYearModifier,
+    SigmaWindowsDashModifier,
+    SigmaTimestampMinuteModifier,
+    SigmaTimestampHourModifier,
+    SigmaTimestampDayModifier,
+    SigmaTimestampWeekModifier,
+    SigmaTimestampMonthModifier,
+    SigmaTimestampYearModifier,
 )
 from sigma.rule import SigmaDetectionItem
 from sigma.types import (
@@ -40,7 +45,9 @@ from sigma.types import (
     SigmaRegularExpression,
     SigmaCompareExpression,
     SigmaCIDRExpression,
-    SpecialChars, TimestampPart, SigmaTimestampPart,
+    SpecialChars,
+    TimestampPart,
+    SigmaTimestampPart,
 )
 from sigma.conditions import ConditionAND
 from sigma.exceptions import SigmaRuleLocation, SigmaTypeError, SigmaValueError

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -18,7 +18,9 @@ from sigma.types import (
     SigmaString,
     SigmaNumber,
     SigmaNull,
-    SigmaRegularExpression, SigmaTimestampPart, TimestampPart,
+    SigmaRegularExpression,
+    SigmaTimestampPart,
+    TimestampPart,
 )
 from sigma.modifiers import (
     SigmaBase64Modifier,
@@ -1615,7 +1617,8 @@ def test_sigmarule_bad_scope():
 
 
 def test_sigmarule_timestamp_modifiers():
-    rule = SigmaRule.from_dict({
+    rule = SigmaRule.from_dict(
+        {
             "title": "Test",
             "logsource": {
                 "category": "process_creation",
@@ -1631,9 +1634,11 @@ def test_sigmarule_timestamp_modifiers():
                     "timestamp|year": 6,
                 },
                 "condition": "selection",
-            }
-    }, source=sigma_exceptions.SigmaRuleLocation("test.yml"),)
-    detection_items = rule.detection['selection'].detection_items
+            },
+        },
+        source=sigma_exceptions.SigmaRuleLocation("test.yml"),
+    )
+    detection_items = rule.detection["selection"].detection_items
     assert detection_items[0].value[0] == SigmaTimestampPart(TimestampPart.MINUTE, 1)
     assert detection_items[1].value[0] == SigmaTimestampPart(TimestampPart.HOUR, 2)
     assert detection_items[2].value[0] == SigmaTimestampPart(TimestampPart.DAY, 3)

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -18,7 +18,7 @@ from sigma.types import (
     SigmaString,
     SigmaNumber,
     SigmaNull,
-    SigmaRegularExpression,
+    SigmaRegularExpression, SigmaTimestampPart, TimestampPart,
 )
 from sigma.modifiers import (
     SigmaBase64Modifier,
@@ -1612,3 +1612,31 @@ def test_sigmarule_bad_scope():
             {"title": "test", "scope": "windows AD"},
             source=sigma_exceptions.SigmaRuleLocation("test.yml"),
         )
+
+
+def test_sigmarule_timestamp_modifiers():
+    rule = SigmaRule.from_dict({
+            "title": "Test",
+            "logsource": {
+                "category": "process_creation",
+                "product": "windows",
+            },
+            "detection": {
+                "selection": {
+                    "timestamp|minute": 1,
+                    "timestamp|hour": 2,
+                    "timestamp|day": 3,
+                    "timestamp|week": 4,
+                    "timestamp|month": 5,
+                    "timestamp|year": 6,
+                },
+                "condition": "selection",
+            }
+    }, source=sigma_exceptions.SigmaRuleLocation("test.yml"),)
+    detection_items = rule.detection['selection'].detection_items
+    assert detection_items[0].value[0] == SigmaTimestampPart(TimestampPart.MINUTE, 1)
+    assert detection_items[1].value[0] == SigmaTimestampPart(TimestampPart.HOUR, 2)
+    assert detection_items[2].value[0] == SigmaTimestampPart(TimestampPart.DAY, 3)
+    assert detection_items[3].value[0] == SigmaTimestampPart(TimestampPart.WEEK, 4)
+    assert detection_items[4].value[0] == SigmaTimestampPart(TimestampPart.MONTH, 5)
+    assert detection_items[5].value[0] == SigmaTimestampPart(TimestampPart.YEAR, 6)


### PR DESCRIPTION
Implement timestamp part modifiers for use in backends.
Adds support for these modifiers that transform a timestamp to a specific time part for use in conditions:
```
|minute
|hour
|day
|week
|month
|year
```

Related to this sigma-specification PR: https://github.com/SigmaHQ/sigma-specification/pull/165