### PR TITLE
[Sigma Filters] Fixes a bug in condition matching logic

### DIFF
--- a/sigma/filters.py
+++ b/sigma/filters.py
@@ -194,7 +194,7 @@ class SigmaFilter(SigmaRuleBase):
 
             # Replace each instance of the original condition name with the new condition name to avoid conflicts
             filter_condition = re.sub(
-                rf"(^|\s){original_cond_name}(\s|$)",
+                rf"(^|\s|\()+{original_cond_name}(\s|$|\))+",
                 cond_name,
                 filter_condition,
             )

--- a/sigma/filters.py
+++ b/sigma/filters.py
@@ -194,8 +194,8 @@ class SigmaFilter(SigmaRuleBase):
 
             # Replace each instance of the original condition name with the new condition name to avoid conflicts
             filter_condition = re.sub(
-                rf"(^|\s|\()+{original_cond_name}(\s|$|\))+",
-                cond_name,
+                rf"(\s|\(|^){original_cond_name}(\s|$|\))",
+                r"\1" + cond_name + r"\2",
                 filter_condition,
             )
             rule.detection.detections[cond_name] = condition

--- a/sigma/filters.py
+++ b/sigma/filters.py
@@ -194,7 +194,7 @@ class SigmaFilter(SigmaRuleBase):
 
             # Replace each instance of the original condition name with the new condition name to avoid conflicts
             filter_condition = re.sub(
-                rf"[^ ]*{original_cond_name}[^ ]*",
+                rf"(^|\s){original_cond_name}(\s|$)",
                 cond_name,
                 filter_condition,
             )

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -341,3 +341,21 @@ def test_regression_github_issue_321_brackets(
     assert test_backend.convert(rule_collection) == [
         '(EventID=4625 or EventID2=4624) and not User startswith "adm_"'
     ]
+
+
+def test_regression_github_issue_321_selection_confusion(rule_collection, test_backend, sigma_filter):
+    sigma_filter.filter = SigmaGlobalFilter.from_dict(
+        {
+            "rules": [
+                "6f3e2987-db24-4c78-a860-b4f4095a7095",
+            ],
+            "filter": {"User|startswith": "adm_"},
+            "condition": "not selection",
+        }
+    )
+
+    rule_collection.rules += [sigma_filter]
+
+    assert test_backend.convert(rule_collection) == [
+        '(EventID=4625 or EventID2=4624) and not User startswith "adm_"'
+    ]

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -323,14 +323,16 @@ def test_regression_github_issue_321(rule_collection, test_backend, sigma_filter
         "not (((filter)))",
     ],
 )
-def test_regression_github_issue_321_brackets(rule_collection, test_backend, sigma_filter, filter_condition):
+def test_regression_github_issue_321_brackets(
+    rule_collection, test_backend, sigma_filter, filter_condition
+):
     sigma_filter.filter = SigmaGlobalFilter.from_dict(
         {
             "rules": [
                 "6f3e2987-db24-4c78-a860-b4f4095a7095",
             ],
             "filter": {"User|startswith": "adm_"},
-            "condition": filter_condition
+            "condition": filter_condition,
         }
     )
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -343,9 +343,16 @@ def test_regression_github_issue_321_brackets(
     ]
 
 
+@pytest.mark.skip("Decision on whether filters should support selection confusion is pending")
 def test_regression_github_issue_321_selection_confusion(
     rule_collection, test_backend, sigma_filter
 ):
+    """
+    This test targets a weird quirk of how we do Filtering, where the filter can just use a
+    selection condition as a filter condition. It's probably not desired behaviour, as you'd
+    rarely want to filter on a selection condition, and it implies that every rule referenced
+    also has to have a selection condition.
+    """
     sigma_filter.filter = SigmaGlobalFilter.from_dict(
         {
             "rules": [

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -308,3 +308,34 @@ def test_regression_github_issue_321(rule_collection, test_backend, sigma_filter
 
     with pytest.raises(SigmaConditionError):
         test_backend.convert(rule_collection)
+
+
+@pytest.mark.parametrize(
+    "filter_condition",
+    [
+        "not filter",
+        "not (filter)",
+        "not ( filter)",
+        "not (filter )",
+        "not ( filter )",
+        "not (   filter   )",
+        "not ((filter))",
+        "not (((filter)))",
+    ],
+)
+def test_regression_github_issue_321_brackets(rule_collection, test_backend, sigma_filter, filter_condition):
+    sigma_filter.filter = SigmaGlobalFilter.from_dict(
+        {
+            "rules": [
+                "6f3e2987-db24-4c78-a860-b4f4095a7095",
+            ],
+            "filter": {"User|startswith": "adm_"},
+            "condition": filter_condition
+        }
+    )
+
+    rule_collection.rules += [sigma_filter]
+
+    assert test_backend.convert(rule_collection) == [
+        '(EventID=4625 or EventID2=4624) and not User startswith "adm_"'
+    ]

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -343,7 +343,9 @@ def test_regression_github_issue_321_brackets(
     ]
 
 
-def test_regression_github_issue_321_selection_confusion(rule_collection, test_backend, sigma_filter):
+def test_regression_github_issue_321_selection_confusion(
+    rule_collection, test_backend, sigma_filter
+):
     sigma_filter.filter = SigmaGlobalFilter.from_dict(
         {
             "rules": [


### PR DESCRIPTION
## Context

This PR fixes a bug in the condition matching logic when Sigma filters have their condition names replaced to avoid naming collisions.

- Fixes #321