### PR TITLE
Prepare Pysigma for EQL Correlations

### DIFF
--- a/sigma/conversion/base.py
+++ b/sigma/conversion/base.py
@@ -1837,6 +1837,7 @@ class TextQueryBackend(Backend):
             template[method].format(
                 search=search,
                 typing=self.convert_correlation_typing(rule),
+                timespan=self.convert_timespan(rule.timespan, method),
                 aggregate=self.convert_correlation_aggregation_from_template(
                     rule, correlation_type, method, search
                 ),


### PR DESCRIPTION
Hi, 

as discussed [here](https://github.com/SigmaHQ/pySigma-backend-elasticsearch/pull/121), this PR adds the possibility to include the `timespan` variable in the correlation rule template and not only in the aggregation template...