### PR TITLE
Prepare for EQL Correlations 

### DIFF
--- a/sigma/conversion/base.py
+++ b/sigma/conversion/base.py
@@ -1844,6 +1844,9 @@ class TextQueryBackend(Backend):
                 condition=self.convert_correlation_condition_from_template(
                     rule.condition, rule.rules, correlation_type, method
                 ),
+                groupby=self.convert_correlation_aggregation_groupby_from_template(
+                    rule.group_by, method
+                ),
             )
         ]
 


### PR DESCRIPTION
Hi, 
I´ve discovered another small prerequisite for the implementation of EQL correlations (https://github.com/SigmaHQ/pySigma-backend-elasticsearch/pull/121)

The correlation template that I´ve come up with currently looks like this

```python
default_correlation_query: ClassVar[str] = {
        "sequence": "sequence {groupby} with maxspan={timespan} \n {search} {aggregate} {condition}",
}
```

As the `{groupby}` is needed outside from the `{aggregate}`, I´ve added it to the `convert_correlation_rule_from_template` just like the timespan parameter before, because I have not found a better way to do it...