### PR TITLE
Finalize all rules, including those which are part of correlation rules

### DIFF
--- a/sigma/conversion/base.py
+++ b/sigma/conversion/base.py
@@ -223,8 +223,6 @@ class Backend(ABC):
                     )
                     for index, query in enumerate(queries)
                 ]
-                if not rule._backreferences
-                else queries
             )
             rule.set_conversion_result(finalized_queries)
             rule.set_conversion_states(states)

--- a/sigma/conversion/base.py
+++ b/sigma/conversion/base.py
@@ -133,6 +133,9 @@ class Backend(ABC):
     collect_errors: bool = False
     errors: List[Tuple[SigmaRule, SigmaError]]
 
+    # query finalization: select queries to be finalized
+    finalize_correlation_subqueries = False
+
     # in-expressions
     convert_or_as_in: ClassVar[bool] = False  # Convert OR as in-expression
     convert_and_as_in: ClassVar[bool] = False  # Convert AND as in-expression
@@ -223,6 +226,8 @@ class Backend(ABC):
                     )
                     for index, query in enumerate(queries)
                 ]
+                if self.finalize_correlation_subqueries or not rule._backreferences
+                else queries
             )
             rule.set_conversion_result(finalized_queries)
             rule.set_conversion_states(states)

--- a/sigma/conversion/base.py
+++ b/sigma/conversion/base.py
@@ -133,7 +133,7 @@ class Backend(ABC):
     collect_errors: bool = False
     errors: List[Tuple[SigmaRule, SigmaError]]
 
-    # query finalization: select queries to be finalized
+    # Perform finalization on all queries used in a correl
     finalize_correlation_subqueries = False
 
     # in-expressions

--- a/tests/test_conversion_correlations.py
+++ b/tests/test_conversion_correlations.py
@@ -465,6 +465,21 @@ def test_correlation_query_postprocessing(event_count_correlation_rule):
         )
     )
     assert test_backend.convert(event_count_correlation_rule) == [
+        """[ EventID=4625
+| aggregate window=5min count() as event_count by TargetUserName, TargetDomainName, fieldB
+| where event_count >= 10 ]"""
+    ]
+
+def test_correlation_subqueries_finalization(monkeypatch,event_count_correlation_rule):
+    test_backend = TextQueryTestBackend(
+        ProcessingPipeline(
+            postprocessing_items=[
+                QueryPostprocessingItem(EmbedQueryTransformation(prefix="[ ", suffix=" ]"))
+            ]
+        )
+    )
+    monkeypatch.setattr(test_backend, "finalize_correlation_subqueries", True)
+    assert test_backend.convert(event_count_correlation_rule) == [
         """[ [ EventID=4625 ]
 | aggregate window=5min count() as event_count by TargetUserName, TargetDomainName, fieldB
 | where event_count >= 10 ]"""

--- a/tests/test_conversion_correlations.py
+++ b/tests/test_conversion_correlations.py
@@ -470,7 +470,8 @@ def test_correlation_query_postprocessing(event_count_correlation_rule):
 | where event_count >= 10 ]"""
     ]
 
-def test_correlation_subqueries_finalization(monkeypatch,event_count_correlation_rule):
+
+def test_correlation_subqueries_finalization(monkeypatch, event_count_correlation_rule):
     test_backend = TextQueryTestBackend(
         ProcessingPipeline(
             postprocessing_items=[

--- a/tests/test_conversion_correlations.py
+++ b/tests/test_conversion_correlations.py
@@ -465,7 +465,7 @@ def test_correlation_query_postprocessing(event_count_correlation_rule):
         )
     )
     assert test_backend.convert(event_count_correlation_rule) == [
-        """[ EventID=4625
+        """[ [ EventID=4625 ]
 | aggregate window=5min count() as event_count by TargetUserName, TargetDomainName, fieldB
 | where event_count >= 10 ]"""
     ]


### PR DESCRIPTION
Following an [issue](https://github.com/SigmaHQ/pySigma-backend-splunk/issues/52#issue-2966238569) on the splunk backend, I made a [PR](https://github.com/SigmaHQ/pySigma-backend-splunk/pull/53#issue-2972219139) which requires to apply `finalize_query` on all rules, even those that are part of correlation rules, reversing the #278 PR on pysigma.