### PR TITLE
Add condition existence check in post-init method

### DIFF
--- a/sigma/rule/detection.py
+++ b/sigma/rule/detection.py
@@ -454,6 +454,10 @@ class SigmaDetections:
             raise sigma_exceptions.SigmaDetectionError(
                 "No detections defined in Sigma rule", source=self.source
             )
+        if self.condition == [] or self.condition is None:
+            raise sigma_exceptions.SigmaConditionError(
+                "Sigma rule must contain at least one condition", source=self.source
+            )
         self.parsed_condition = [SigmaCondition(cond, self, self.source) for cond in self.condition]
 
     @classmethod

--- a/tests/test_conditions.py
+++ b/tests/test_conditions.py
@@ -45,7 +45,7 @@ def sigma_simple_detections():
                 ]
             ),
         },
-        list(),
+        condition=["any of them"],
     )
 
 
@@ -142,7 +142,7 @@ def sigma_detections():
                 ]
             ),
         },
-        list(),
+        condition=["any of them"],
     )
 
 
@@ -156,7 +156,7 @@ def sigma_invalid_detections():
                 ]
             ),
         },
-        list(),
+        condition=["any of them"],
     )
 
 
@@ -180,7 +180,7 @@ def sigma_underscore_detections():
                 ]
             ),
         },
-        list(),
+        condition=["any of them"],
     )
 
 

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -622,6 +622,32 @@ def test_sigmadetections_fromdict_no_condition():
         )
 
 
+def test_sigmadetections_empty_condition_list():
+    with pytest.raises(
+        sigma_exceptions.SigmaConditionError, match="at least one condition.*test.yml"
+    ):
+        SigmaDetections(
+            detections={
+                "selection": SigmaDetection([SigmaDetectionItem("key", [], [SigmaString("value")])])
+            },
+            condition=[],
+            source=sigma_exceptions.SigmaRuleLocation("test.yml"),
+        )
+
+
+def test_sigmadetections_none_condition():
+    with pytest.raises(
+        sigma_exceptions.SigmaConditionError, match="at least one condition.*test.yml"
+    ):
+        SigmaDetections(
+            detections={
+                "selection": SigmaDetection([SigmaDetectionItem("key", [], [SigmaString("value")])])
+            },
+            condition=None,
+            source=sigma_exceptions.SigmaRuleLocation("test.yml"),
+        )
+
+
 def test_detectionitem_all_modified_key_plain_values_postprocess():
     """
     Test if postprocessed condition result of an all-modified field-bound value list results in an


### PR DESCRIPTION
Introduce a validation step in the post-init method to ensure that a Sigma rule contains at least one condition. This change raises an error if the condition is empty or None. Additionally, add tests to verify the behavior when no conditions are provided.