### PR TITLE
Propagate errors from SigmaRule to SigmaCollection

### DIFF
--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -266,6 +266,14 @@ def test_load_ruleset_with_error():
         SigmaCollection.load_ruleset([Path("tests/files/ruleset_with_errors")])
 
 
+def test_load_ruleset_with_error_collect_errors():
+    sc = SigmaCollection.load_ruleset(
+        [Path("tests/files/ruleset_with_errors")], collect_errors=True
+    )
+    assert len(sc.errors) > 0
+    assert len(sc.rules) == 1
+
+
 def test_load_ruleset_nolist():
     with pytest.raises(TypeError, match="must be list"):
         SigmaCollection.load_ruleset("tests/files/ruleset")


### PR DESCRIPTION
Ensure that errors from contained rule objects are propagated to the SigmaCollection when invoked with `collect_errors=True`. This change addresses issue #345 by enhancing error handling within the collection process.