### PR TITLE
fix(SigmaRegularExpression): invalid escapements

### DIFF
--- a/sigma/types.py
+++ b/sigma/types.py
@@ -116,7 +116,7 @@ class SigmaString(SigmaType):
         Union[str, SpecialChars, Placeholder]
     ]  # the string is represented as sequence of strings and characters with special meaning
 
-    def __init__(self, s: Optional[str] = None, escape: Optional[bool] = True):
+    def __init__(self, s: Optional[str] = None, escape: bool = True):
         """
         Initializes SigmaString instance from raw string by parsing it:
 

--- a/sigma/types.py
+++ b/sigma/types.py
@@ -126,7 +126,7 @@ class SigmaString(SigmaType):
 
         :param s: string to be parsed
         :type s: str
-        :param escape: if True, escape_char is used to escape special characters
+        :param escape: whether to enable escaping of special characters
         :type escape: bool
         """
         if s is None:

--- a/sigma/types.py
+++ b/sigma/types.py
@@ -116,13 +116,18 @@ class SigmaString(SigmaType):
         Union[str, SpecialChars, Placeholder]
     ]  # the string is represented as sequence of strings and characters with special meaning
 
-    def __init__(self, s: Optional[str] = None):
+    def __init__(self, s: Optional[str] = None, escape: Optional[bool] = True):
         """
         Initializes SigmaString instance from raw string by parsing it:
 
         * characters from char_mapping are interpreted as special characters and interrupt the plain string in the resulting sequence
         * escape_char disables special character mapping in the next character
         * if escaping character is followed by a character without special meaning the escaping character is used as plain character
+
+        :param s: string to be parsed
+        :type s: str
+        :param escape: if True, escape_char is used to escape special characters
+        :type escape: bool
         """
         if s is None:
             s = ""
@@ -141,7 +146,9 @@ class SigmaString(SigmaType):
                 else:  # accumulate escaping and current character (this allows to use plain backslashes in values)
                     acc += escape_char + c
                 escaped = False
-            elif c == escape_char:  # escaping character? enable escaped mode for next character
+            elif (
+                c == escape_char and escape
+            ):  # escaping character? enable escaped mode for next character
                 escaped = True
             else:  # "normal" string parsing
                 if c in char_mapping:  # character is special character?
@@ -712,7 +719,7 @@ class SigmaRegularExpression(SigmaType):
         regexp_init: Union[str, SigmaString],
     ):
         if isinstance(regexp_init, str):
-            regexp_init = SigmaString(regexp_init)
+            regexp_init = SigmaString(regexp_init, escape=False)
 
         self.regexp = regexp_init
         self.compile()
@@ -726,11 +733,14 @@ class SigmaRegularExpression(SigmaType):
             flags = 0
             for flag in self.flags:
                 flags |= self.sigma_to_python_flags[flag]
-            re.compile(self.escape(), flags)
+            re.compile(str(self.regexp), flags)
         except re.error as e:
             raise SigmaRegularExpressionError(
-                f"Regular expression '{self.escape()}' is invalid: {str(e)}"
+                f"Regular expression '{str(self.regexp)}' is invalid: {str(e)}"
             ) from e
+
+    def to_plain(self) -> str:
+        return self.regexp.to_plain()
 
     def escape(
         self,

--- a/tests/test_conversion_base.py
+++ b/tests/test_conversion_base.py
@@ -227,6 +227,27 @@ def test_convert_value_str_empty(test_backend):
     )
 
 
+def test_convert_value_str_invalid_re(test_backend):
+    assert (
+        test_backend.convert(
+            SigmaCollection.from_yaml(
+                """
+            title: Test
+            status: test
+            logsource:
+                category: test_category
+                product: test_product
+            detection:
+                sel:
+                    field: (value
+                condition: sel
+            """
+            )
+        )
+        == ['field="(value"']
+    )
+
+
 def test_convert_value_str_quote_pattern_match(test_backend, monkeypatch):
     monkeypatch.setattr(test_backend, "str_quote_pattern", re.compile("^.*\\s"))
     monkeypatch.setattr(test_backend, "str_quote_pattern_negation", False)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -399,13 +399,13 @@ def test_strings_to_regex():
         "(Plain)/[*?]",
     )
     r = s.to_regex()
-    assert r.regexp == "Test.*Special.\\(Plain\\)/\\[\\*\\?\\]"
+    assert str(r.regexp) == "Test.*Special.\\(Plain\\)/\\[\\*\\?\\]"
 
 
 def test_strings_to_regex_with_additional_escape_chars():
     s = SigmaString("Test*Special?(Plain)/[\\*\\?]")
     r = s.to_regex("/")
-    assert r.regexp == "Test.*Special.\\(Plain\\)\\/\\[\\*\\?\\]"
+    assert str(r.regexp) == "Test.*Special.\\(Plain\\)\\/\\[\\*\\?\\]"
 
 
 def test_string_index(sigma_string):


### PR DESCRIPTION
Closes https://github.com/SigmaHQ/pySigma/issues/346

This PR aims to fix work started in https://github.com/SigmaHQ/pySigma/pull/322 to make `SigmaRegularExpression` use `SigmaString` under the hood. The current implementation modifies the input string escapement when passing it to `SigmaString` constructor:

```py
        if isinstance(regexp_init, str):
            regexp_init = SigmaString(regexp_init)
```

And tries to restore the original escapement before compiling it:

```py
re.compile(self.escape(), flags)
```

Unfortunately, `escape` is not able to restore the original escapement depending on the `SigmaString` input which causes some side-effect as demonstrated in the added unit test.

Simply keeping the escapement as-is by passing an additional parameter to `SigmaString` better reflects the regular expression stored internally and prevent implementing additional logic to restore the original escapement.