### PR TITLE
Fix the sigmadetections to dict test case

### DIFF
--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -574,7 +574,7 @@ def test_sigmadetections_to_dict_single_condition():
     ).to_dict() == {"test": {"field": "value"}, "condition": "test"}
 
 
-def test_sigmadetections_to_dict_single_condition():
+def test_sigmadetections_to_dict_double_condition():
     assert SigmaDetections(
         detections={
             "test": SigmaDetection([SigmaDetectionItem("field", [], SigmaString("value"))])


### PR DESCRIPTION
## PR Summary
This small PR fixes the `test_sigmadetections_to_dict_double_condition` duplicated test case.