### PR TITLE
Fix timestamp handling when paired with `|gt` `|gte` `|lt` and `|lte`…

### DIFF
--- a/sigma/conversion/base.py
+++ b/sigma/conversion/base.py
@@ -1809,6 +1809,8 @@ class TextQueryBackend(Backend):
             isinstance(cond.value, SigmaCompareExpression)
             and cond.value.number
             and isinstance(cond.value.number, SigmaTimestampPart)
+            and self.field_timestamp_part_expression
+            and self.timestamp_part_mapping
         ):
             return (
                 self.field_timestamp_part_expression.format(

--- a/sigma/conversion/base.py
+++ b/sigma/conversion/base.py
@@ -1805,11 +1805,17 @@ class TextQueryBackend(Backend):
                 "Expected SigmaCompareExpression for cond.value, got {type(cond_value)}"
             )
 
-        return self.compare_op_expression.format(
-            field=self.escape_and_quote_field(cond.field),
-            operator=self.compare_operators[cond_value.op],
-            value=cond_value.number,
-        )
+        if isinstance(cond.value, SigmaCompareExpression) and cond.value.number and isinstance(cond.value.number, SigmaTimestampPart):
+            return self.field_timestamp_part_expression.format(
+                        field=self.escape_and_quote_field(cond.field),
+                        timestamp_part=self.timestamp_part_mapping[cond.value.number.timestamp_part],
+                    ) + self.compare_operators[cond_value.op] + str(cond.value.number)
+        else:
+            return self.compare_op_expression.format(
+                field=self.escape_and_quote_field(cond.field),
+                operator=self.compare_operators[cond_value.op],
+                value=cond_value.number,
+            )
 
     def convert_condition_field_eq_field_escape_and_quote(
         self, field1: str, field2: str

--- a/sigma/conversion/base.py
+++ b/sigma/conversion/base.py
@@ -1805,11 +1805,19 @@ class TextQueryBackend(Backend):
                 "Expected SigmaCompareExpression for cond.value, got {type(cond_value)}"
             )
 
-        if isinstance(cond.value, SigmaCompareExpression) and cond.value.number and isinstance(cond.value.number, SigmaTimestampPart):
-            return self.field_timestamp_part_expression.format(
-                        field=self.escape_and_quote_field(cond.field),
-                        timestamp_part=self.timestamp_part_mapping[cond.value.number.timestamp_part],
-                    ) + self.compare_operators[cond_value.op] + str(cond.value.number)
+        if (
+            isinstance(cond.value, SigmaCompareExpression)
+            and cond.value.number
+            and isinstance(cond.value.number, SigmaTimestampPart)
+        ):
+            return (
+                self.field_timestamp_part_expression.format(
+                    field=self.escape_and_quote_field(cond.field),
+                    timestamp_part=self.timestamp_part_mapping[cond.value.number.timestamp_part],
+                )
+                + self.compare_operators[cond_value.op]
+                + str(cond.value.number)
+            )
         else:
             return self.compare_op_expression.format(
                 field=self.escape_and_quote_field(cond.field),

--- a/tests/test_conversion_base.py
+++ b/tests/test_conversion_base.py
@@ -3500,6 +3500,6 @@ def test_convert_timestamp_part_modifiers(test_backend, monkeypatch):
             )
         )
         == [
-            'strftime(timestamp, "%M")=1 and strftime(timestamp, "%H")=2 and strftime(timestamp, "%d")=3 and strftime(timestamp, "%V")=4 and strftime(timestamp, "%m")=5 and strftime(timestamp, "%Y")=6 and timestamp>7 and timestamp>=8 and timestamp<9 and timestamp<=10 and timestamp>11 and timestamp>=12'
+            'strftime(timestamp, "%M")=1 and strftime(timestamp, "%H")=2 and strftime(timestamp, "%d")=3 and strftime(timestamp, "%V")=4 and strftime(timestamp, "%m")=5 and strftime(timestamp, "%Y")=6 and strftime(timestamp, "%M")>7 and strftime(timestamp, "%H")>=8 and strftime(timestamp, "%d")<9 and strftime(timestamp, "%V")<=10 and strftime(timestamp, "%m")>11 and strftime(timestamp, "%Y")>=12'
         ]
     )

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -20,7 +20,7 @@ from sigma.types import (
     SigmaNull,
     SigmaRegularExpression,
     SigmaTimestampPart,
-    TimestampPart,
+    TimestampPart, SigmaCompareExpression,
 )
 from sigma.modifiers import (
     SigmaBase64Modifier,
@@ -1692,7 +1692,7 @@ def test_sigmarule_bad_scope():
         )
 
 
-def test_sigmarule_timestamp_modifiers():
+def test_sigmarule_timestamp_modifiers_equals():
     rule = SigmaRule.from_dict(
         {
             "title": "Test",
@@ -1721,3 +1721,35 @@ def test_sigmarule_timestamp_modifiers():
     assert detection_items[3].value[0] == SigmaTimestampPart(TimestampPart.WEEK, 4)
     assert detection_items[4].value[0] == SigmaTimestampPart(TimestampPart.MONTH, 5)
     assert detection_items[5].value[0] == SigmaTimestampPart(TimestampPart.YEAR, 6)
+
+
+def test_sigmarule_timestamp_modifiers_greater_than():
+    rule = SigmaRule.from_dict(
+        {
+            "title": "Test",
+            "logsource": {
+                "category": "process_creation",
+                "product": "windows",
+            },
+            "detection": {
+                "selection": {
+                    "timestamp|minute|gt": 1,
+                    "timestamp|hour|gte": 2,
+                    "timestamp|day|lt": 3,
+                    "timestamp|week|lte": 4,
+                    "timestamp|month|gt": 5,
+                    "timestamp|year|gte": 6,
+                },
+                "condition": "selection",
+            },
+        },
+        source=sigma_exceptions.SigmaRuleLocation("test.yml"),
+    )
+    detection_items = rule.detection["selection"].detection_items
+    assert isinstance(detection_items[0].value[0], SigmaCompareExpression)
+    assert detection_items[0].value[0].number == SigmaTimestampPart(TimestampPart.MINUTE, 1)
+    assert detection_items[1].value[0].number == SigmaTimestampPart(TimestampPart.HOUR, 2)
+    assert detection_items[2].value[0].number == SigmaTimestampPart(TimestampPart.DAY, 3)
+    assert detection_items[3].value[0].number == SigmaTimestampPart(TimestampPart.WEEK, 4)
+    assert detection_items[4].value[0].number == SigmaTimestampPart(TimestampPart.MONTH, 5)
+    assert detection_items[5].value[0].number == SigmaTimestampPart(TimestampPart.YEAR, 6)

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -20,7 +20,8 @@ from sigma.types import (
     SigmaNull,
     SigmaRegularExpression,
     SigmaTimestampPart,
-    TimestampPart, SigmaCompareExpression,
+    TimestampPart,
+    SigmaCompareExpression,
 )
 from sigma.modifiers import (
     SigmaBase64Modifier,


### PR DESCRIPTION
Fix timestamp handling when paired with `|gt` `|gte` `|lt` and `|lte` modifiers.
Big oversight on my part, sorry!