### PR TITLE
Include rule scope in SigmaRule.to_dict()

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        os: ["ubuntu-latest", "windows-latest", "macos-latest", "ubuntu-24.04-arm"]
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}
     steps:

--- a/sigma/rule/base.py
+++ b/sigma/rule/base.py
@@ -391,8 +391,8 @@ class SigmaRuleBase:
                 d[field] = str(s)
 
         # copy list of strings
-        for field in ("references", "fields", "falsepositives"):
-            if len(l := self.__getattribute__(field)) > 0:
+        for field in ("references", "fields", "falsepositives", "scope"):
+            if (l := self.__getattribute__(field)) is not None and len(l) > 0:
                 d[field] = l.copy()
 
         # the special cases

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -1267,6 +1267,10 @@ def sigma_rule():
             "Everything",
         ],
         level=SigmaLevel.LOW,
+        scope=[
+            "scope1",
+            "scope2",
+        ]
     )
 
 
@@ -1306,6 +1310,9 @@ def test_sigmarule_fromyaml(sigma_rule):
     falsepositives:
         - Everything
     level: low
+    scope:
+        - scope1
+        - scope2     
     """
     )
     assert sigmarule_from_yaml == sigma_rule
@@ -1348,6 +1355,9 @@ def test_sigmarule_fromyaml_with_custom_attribute(sigma_rule):
         - Everything
     level: low
     custom: attribute
+    scope:
+        - scope1
+        - scope2    
     """
     )
     assert sigmarule_from_yaml == sigma_rule
@@ -1414,6 +1424,7 @@ def test_sigmarule_to_dict(sigma_rule: SigmaRule):
             "Everything",
         ],
         "level": "low",
+        "scope": ["scope1", "scope2"],
     }
 
 

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -1270,7 +1270,7 @@ def sigma_rule():
         scope=[
             "scope1",
             "scope2",
-        ]
+        ],
     )
 
 


### PR DESCRIPTION
- A rule’s scope was not being included in the response from SigmaRule.to_dict(). This PR updates the method to include it.
- Tests have been updated to reflect this.
- Added ARM to testing.

I’m happy to resubmit this without the ARM addition to testing if you’d prefer. All the tests do pass on ARM, and while I can’t see anything architecture-specific in pySigma itself, some dependencies (such as PyYAML) do use architecture-specific binaries, so I feel it’s a nice thing to check (given that it's also little effort).