### PR TITLE
Preserve type when slicing SigmaCasedString

### DIFF
--- a/sigma/types.py
+++ b/sigma/types.py
@@ -215,7 +215,7 @@ class SigmaString(SigmaType):
 
         # Range checks
         if start > end or start >= length:
-            return SigmaString("")
+            return self.__class__("")
         if start < 0 or end < 0 or (end != inf and end > length):
             raise IndexError("SigmaString index out of range")
 
@@ -232,7 +232,7 @@ class SigmaString(SigmaType):
                 if e_len > start:
                     # else:
                     if end < e_len:  # end lies within this string part
-                        return SigmaString(e[start : cast(int, end)])
+                        return self.__class__(e[start : cast(int, end)])
                     else:  # end lies behind the current string part
                         result.append(e[start:])
                         # end -= start
@@ -262,9 +262,9 @@ class SigmaString(SigmaType):
             i += 1
 
         if len(result) == 0:  # Special case: start begins after string - return empty string
-            return SigmaString("")
+            return self.__class__("")
         else:  # Return calculated result
-            s = SigmaString()
+            s = self.__class__()
             s.s = result
             return s
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -467,6 +467,11 @@ def test_string_index_slice_start_after_end(sigma_string):
 def test_string_index_slice_open_start_negative_end(sigma_string):
     assert sigma_string[:-1] == SigmaString("*Test*Str\\*ing")
 
+def test_string_index_cased_index():
+    assert SigmaCasedString("TestCasedString")[4:9] == SigmaCasedString("Cased")
+
+def test_string_index_cased_type():
+    assert type(SigmaCasedString("TestCasedString")[4:9]) is SigmaCasedString
 
 def test_string_index_invalid_type(sigma_string):
     with pytest.raises(TypeError, match="indices must be"):

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -467,11 +467,14 @@ def test_string_index_slice_start_after_end(sigma_string):
 def test_string_index_slice_open_start_negative_end(sigma_string):
     assert sigma_string[:-1] == SigmaString("*Test*Str\\*ing")
 
+
 def test_string_index_cased_index():
     assert SigmaCasedString("TestCasedString")[4:9] == SigmaCasedString("Cased")
 
+
 def test_string_index_cased_type():
     assert type(SigmaCasedString("TestCasedString")[4:9]) is SigmaCasedString
+
 
 def test_string_index_invalid_type(sigma_string):
     with pytest.raises(TypeError, match="indices must be"):


### PR DESCRIPTION
### Summary
Slicing a `SigmaCasedString` currently returns a `SigmaString`. This PR preserves the concrete type so that `SigmaCasedString` remains `SigmaCasedString` after slicing, matching the behaviour of other `SigmaString` operations.

### Motivation
Downstream code may rely on the specific string subtype. For example, in [`conversion/base.py L1677`](https://github.com/SigmaHQ/pySigma/blob/62ead81c5fa3798f28b8434844abcf2509edf97a/sigma/conversion/base.py#L1677) we're explicitly working with `SigmaCasedString`, but a slice converts it to `SigmaString`. Subsequent functions (e.g. `convert_value_str()`) then lose the ability to detect the original type.

### Behaviour
The current behaviour is:
```python
type(SigmaCasedString("TestCasedString")[4:9]) is SigmaString
```

The new behaviour is:
```python
type(SigmaCasedString("TestCasedString")[4:9]) is SigmaCasedString
```

Two simple tests have been added to cover this behaviour.


