### PR TITLE
Resolve rule references in SigmaCollection initialization by default.

### DIFF
--- a/tests/test_correlations.py
+++ b/tests/test_correlations.py
@@ -603,7 +603,6 @@ detection:
 
 
 def test_correlation_reference_flattening(nested_correlation_rule):
-    nested_correlation_rule.resolve_rule_references()
     flattened_rule_ids = [
         rule.name for rule in nested_correlation_rule["test_correlation"].flatten_rules()
     ]
@@ -611,7 +610,6 @@ def test_correlation_reference_flattening(nested_correlation_rule):
 
 
 def test_correlation_reference_flattening_without_correlations(nested_correlation_rule):
-    nested_correlation_rule.resolve_rule_references()
     flattened_rule_ids = [
         rule.name
         for rule in nested_correlation_rule["test_correlation"].flatten_rules(

--- a/tests/test_processing_conditions.py
+++ b/tests/test_processing_conditions.py
@@ -102,28 +102,24 @@ def test_logsource_no_match(sigma_rule):
 
 
 def test_logsource_match_correlation_rule_cat(sigma_correlated_rules):
-    sigma_correlated_rules.resolve_rule_references()
     assert LogsourceCondition(category="test_category").match(
         cast(SigmaCorrelationRule, sigma_correlated_rules.rules[-1]),
     )
 
 
 def test_logsource_match_correlation_rule_prod(sigma_correlated_rules):
-    sigma_correlated_rules.resolve_rule_references()
     assert LogsourceCondition(product="test_product").match(
         cast(SigmaCorrelationRule, sigma_correlated_rules.rules[-1]),
     )
 
 
 def test_logsource_no_match_correlation_rule_both(sigma_correlated_rules):
-    sigma_correlated_rules.resolve_rule_references()
     assert not LogsourceCondition(category="test_category", product="test_product").match(
         cast(SigmaCorrelationRule, sigma_correlated_rules.rules[-1]),
     )
 
 
 def test_logsource_no_match_correlation_rule(sigma_correlated_rules):
-    sigma_correlated_rules.resolve_rule_references()
     assert not LogsourceCondition(service="test_service").match(
         cast(SigmaCorrelationRule, sigma_correlated_rules.rules[-1]),
     )

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -44,7 +44,7 @@ def test_sigmavalidator_validate_rules(rule_with_id, rule_without_id, rules_with
 
 
 def test_sigmavalidator_validate_correlation_rules(correlation_rule):
-    rules = SigmaCollection([correlation_rule])
+    rules = SigmaCollection([correlation_rule], resolve_references=False)
     validator = SigmaValidator(
         {IdentifierExistenceValidator, IdentifierUniquenessValidator, DanglingDetectionValidator}
     )


### PR DESCRIPTION
Introduced resolve_references parameter to override this behavior.