### PR TITLE
Add backend name and output format to processing pipeline variables

### DIFF
--- a/sigma/conversion/base.py
+++ b/sigma/conversion/base.py
@@ -189,6 +189,8 @@ class Backend(ABC):
         self.last_processing_pipeline.vars.update(
             {"backend_" + key: value for key, value in self.backend_options.items()}
         )
+        self.last_processing_pipeline.vars["backend"] = self.name
+        self.last_processing_pipeline.vars["output_format"] = output_format or self.default_format
 
     def convert(
         self,

--- a/tests/test_conversion_base.py
+++ b/tests/test_conversion_base.py
@@ -110,7 +110,10 @@ def test_backend_options_passing_to_pipeline():
             """
         )
     )
-    assert test_backend.last_processing_pipeline.vars["backend_test"] == "testvalue"
+    vars = test_backend.last_processing_pipeline.vars
+    assert vars["backend"] == "Test backend"
+    assert vars["output_format"] == "default"
+    assert vars["backend_test"] == "testvalue"
     assert result == ["query='field=\"value\"', state=testvalue"]
 
 


### PR DESCRIPTION
Enhance the processing pipeline by including the backend name and output format in the pipeline variables. This improvement facilitates the creation of reusable Jinja2 templates that can adapt based on the backend and target.

Fixes #342