### PR TITLE
Use __future_.annotations for type hinting

### DIFF
--- a/sigma/filters.py
+++ b/sigma/filters.py
@@ -1,19 +1,17 @@
+from __future__ import annotations
+
 import random
 import re
 import string
 from dataclasses import dataclass, field
-from typing import Any, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from sigma import exceptions as sigma_exceptions
 from sigma.correlations import SigmaCorrelationRule, SigmaRuleReference
-from sigma.exceptions import SigmaRuleLocation
-from sigma.rule import (
-    SigmaLogSource,
-    SigmaDetections,
-    SigmaDetection,
-    SigmaRule,
-    SigmaRuleBase,
-)
+from sigma.rule import SigmaDetection, SigmaDetections, SigmaLogSource, SigmaRule, SigmaRuleBase
+
+if TYPE_CHECKING:
+    from sigma.exceptions import SigmaRuleLocation
 
 
 @dataclass
@@ -22,8 +20,8 @@ class SigmaGlobalFilter(SigmaDetections):
 
     @classmethod
     def from_dict(
-        cls, detections: dict[str, Any], source: Optional[SigmaRuleLocation] = None
-    ) -> "SigmaGlobalFilter":
+        cls, detections: dict[str, Any], source: SigmaRuleLocation | None = None
+    ) -> SigmaGlobalFilter:
         try:
             if isinstance(detections["condition"], str):
                 condition = [detections["condition"]]
@@ -93,8 +91,8 @@ class SigmaFilter(SigmaRuleBase):
         cls,
         sigma_filter: dict[str, Any],
         collect_errors: bool = False,
-        source: Optional[SigmaRuleLocation] = None,
-    ) -> "SigmaFilter":
+        source: SigmaRuleLocation | None = None,
+    ) -> SigmaFilter:
         """
         Converts from a dictionary object to a SigmaFilter object.
         """
@@ -158,7 +156,7 @@ class SigmaFilter(SigmaRuleBase):
 
         return d
 
-    def _should_apply_on_rule(self, rule: Union[SigmaRule, SigmaCorrelationRule]) -> bool:
+    def _should_apply_on_rule(self, rule: SigmaRule | SigmaCorrelationRule) -> bool:
         from sigma.collection import SigmaCollection
 
         if not self.filter.rules or isinstance(rule, SigmaCorrelationRule):
@@ -182,8 +180,8 @@ class SigmaFilter(SigmaRuleBase):
         return True
 
     def apply_on_rule(
-        self, rule: Union[SigmaRule, SigmaCorrelationRule]
-    ) -> Union[SigmaRule, SigmaCorrelationRule]:
+        self, rule: SigmaRule | SigmaCorrelationRule
+    ) -> SigmaRule | SigmaCorrelationRule:
         if not self._should_apply_on_rule(rule) or isinstance(rule, SigmaCorrelationRule):
             return rule
 
@@ -208,6 +206,6 @@ class SigmaFilter(SigmaRuleBase):
         return rule
 
     @classmethod
-    def from_yaml(cls, rule: str, collect_errors: bool = False) -> "SigmaFilter":
+    def from_yaml(cls, rule: str, collect_errors: bool = False) -> SigmaFilter:
         """Convert YAML input string with single document into SigmaFilter object."""
-        return cast(SigmaFilter, super().from_yaml(rule, collect_errors))
+        return cast("SigmaFilter", super().from_yaml(rule, collect_errors))

--- a/sigma/rule/detection.py
+++ b/sigma/rule/detection.py
@@ -1,43 +1,41 @@
-from dataclasses import InitVar, dataclass, field
+from __future__ import annotations
+
 import dataclasses
-from typing import Optional, Union, Sequence, Mapping, Type, Any, cast, TYPE_CHECKING
-from sigma.types import SigmaType, SigmaNull, SigmaString, sigma_type
-from sigma.modifiers import (
-    SigmaModifier,
-    SigmaRegularExpressionModifier,
-    modifier_mapping,
-    reverse_modifier_mapping,
-    SigmaValueModifier,
-    SigmaListModifier,
-)
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, cast
+
+import sigma.exceptions as sigma_exceptions
 from sigma.conditions import (
-    SigmaCondition,
-    ConditionItem,
     ConditionAND,
-    ConditionOR,
     ConditionFieldEqualsValueExpression,
+    ConditionItem,
+    ConditionOR,
     ConditionValueExpression,
     ParentChainMixin,
+    SigmaCondition,
+)
+from sigma.exceptions import SigmaRuleLocation, SigmaTypeError
+from sigma.modifiers import (
+    SigmaListModifier,
+    SigmaModifier,
+    SigmaRegularExpressionModifier,
+    SigmaValueModifier,
+    modifier_mapping,
+    reverse_modifier_mapping,
 )
 from sigma.processing.tracking import ProcessingItemTrackingMixin
-import sigma.exceptions as sigma_exceptions
-from sigma.exceptions import SigmaRuleLocation, SigmaTypeError
+from sigma.types import SigmaNull, SigmaString, SigmaType, sigma_type
 
 if TYPE_CHECKING:
     from sigma.processing.pipeline import ProcessingItemBase
 
 # Type alias for plain detection types
-SigmaDetectionPlainList = list[Union[str, int, float, bool, None]]
-SigmaDetectionPlainDict = dict[str, Union[str, int, float, bool, SigmaDetectionPlainList, None]]
-SigmaDetectionPlainTypes = Union[
-    SigmaDetectionPlainDict,
-    SigmaDetectionPlainList,
-    str,
-    int,
-    float,
-    bool,
-    None,
-]
+SigmaDetectionPlainList = list[str | int | float | bool | None]
+SigmaDetectionPlainDict = dict[str, str | int | float | bool | SigmaDetectionPlainList | None]
+SigmaDetectionPlainTypes = (
+    SigmaDetectionPlainDict | SigmaDetectionPlainList | str | int | float | bool | None
+)
 
 
 @dataclass
@@ -57,12 +55,12 @@ class SigmaDetectionItem(ProcessingItemTrackingMixin, ParentChainMixin):
     the values. This shouldn't normally be used, but only in test scenarios.
     """
 
-    field: Optional[str]  # if None, this is a keyword argument not bound to a field
-    modifiers: list[Type[SigmaModifier[Any, Any]]]
+    field: str | None  # if None, this is a keyword argument not bound to a field
+    modifiers: list[type[SigmaModifier[Any, Any]]]
     value: list[SigmaType]
-    value_linking: Union[Type[ConditionAND], Type[ConditionOR]] = ConditionOR
-    source: Optional[SigmaRuleLocation] = dataclasses.field(default=None, compare=False)
-    original_value: Optional[list[SigmaType]] = dataclasses.field(
+    value_linking: type[ConditionAND | ConditionOR] = ConditionOR
+    source: SigmaRuleLocation | None = dataclasses.field(default=None, compare=False)
+    original_value: list[SigmaType] | None = dataclasses.field(
         init=False, repr=False, hash=False, compare=False
     )  # Copy of original values for conversion back to data structures (and YAML/JSON)
     auto_modifiers: bool = dataclasses.field(default=True, compare=False, repr=False)
@@ -82,7 +80,7 @@ class SigmaDetectionItem(ProcessingItemTrackingMixin, ParentChainMixin):
         """
         Applies modifiers to detection and values
         """
-        applied_modifiers: list[Type[SigmaModifier[Any, Any]]] = list()
+        applied_modifiers: list[type[SigmaModifier[Any, Any]]] = list()
         for modifier in self.modifiers:
             modifier_instance = modifier(self, applied_modifiers, self.source)
             if isinstance(
@@ -103,14 +101,10 @@ class SigmaDetectionItem(ProcessingItemTrackingMixin, ParentChainMixin):
     @classmethod
     def from_mapping(
         cls,
-        key: Optional[str],
-        val: Union[
-            list[Union[int, float, str, bool, None]],
-            Union[int, float, str, bool, None],
-            None,
-        ],
-        source: Optional[SigmaRuleLocation] = None,
-    ) -> "SigmaDetectionItem":
+        key: str | None,
+        val: list[float | str | bool | None] | float | str | bool | None,
+        source: SigmaRuleLocation | None = None,
+    ) -> SigmaDetectionItem:
         """
         Constructs SigmaDetectionItem object from a mapping between field name containing
         modifiers and a value. This also supports keys containing only value modifiers
@@ -141,7 +135,7 @@ class SigmaDetectionItem(ProcessingItemTrackingMixin, ParentChainMixin):
         sigma_val = [
             (
                 SigmaString.from_str(
-                    cast(str, v)
+                    cast("str", v),
                 )  # The string type is ensured previously by the 're' modifier.
                 if SigmaRegularExpressionModifier in modifiers
                 else sigma_type(v)
@@ -154,13 +148,9 @@ class SigmaDetectionItem(ProcessingItemTrackingMixin, ParentChainMixin):
     @classmethod
     def from_value(
         cls,
-        val: Union[
-            list[Union[int, float, str, bool, None]],
-            Union[int, float, str, bool, None],
-            None,
-        ],
-        source: Optional[SigmaRuleLocation] = None,
-    ) -> "SigmaDetectionItem":
+        val: list[float | str | bool | None] | float | str | bool | None,
+        source: SigmaRuleLocation | None = None,
+    ) -> SigmaDetectionItem:
         """Convenience method for from_mapping(None, value)."""
         return cls.from_mapping(None, val, source=source)
 
@@ -189,7 +179,7 @@ class SigmaDetectionItem(ProcessingItemTrackingMixin, ParentChainMixin):
             )
 
         if len(self.original_value) > 1:
-            value: Union[str, int, float, bool, None, list[Union[str, int, float, bool, None]]] = [
+            value: str | int | float | bool | None | list[str | int | float | bool | None] = [
                 (
                     value.to_plain(True)
                     if isinstance(value, SigmaString)
@@ -225,17 +215,17 @@ class SigmaDetectionItem(ProcessingItemTrackingMixin, ParentChainMixin):
 
     def postprocess(
         self,
-        detections: "SigmaDetections",
-        parent: Optional[Union["SigmaDetection", "SigmaDetectionItem", "ConditionItem"]] = None,
-        source: Optional[SigmaRuleLocation] = None,
-    ) -> Union[
-        ConditionItem,
-        ConditionAND,
-        ConditionOR,
-        ConditionFieldEqualsValueExpression,
-        ConditionValueExpression,
-        None,
-    ]:
+        detections: SigmaDetections,
+        parent: SigmaDetection | SigmaDetectionItem | ConditionItem | None = None,
+        source: SigmaRuleLocation | None = None,
+    ) -> (
+        ConditionItem
+        | ConditionAND
+        | ConditionOR
+        | ConditionFieldEqualsValueExpression
+        | ConditionValueExpression
+        | None
+    ):
         super().postprocess(detections, parent, source)
         if len(self.value) == 0:  # no value: map to none type
             if self.field is None:
@@ -283,9 +273,9 @@ class SigmaDetection(ParentChainMixin):
     3. a list of plain values or mappings defined and matched as in 1 where at least one of the items should appear in matched events.
     """
 
-    detection_items: list[Union[SigmaDetectionItem, "SigmaDetection"]]
-    source: Optional[SigmaRuleLocation] = field(default=None, compare=False)
-    item_linking: Union[Type[ConditionAND], Type[ConditionOR], None] = field(default=None)
+    detection_items: list[SigmaDetectionItem | SigmaDetection]
+    source: SigmaRuleLocation | None = field(default=None, compare=False)
+    item_linking: type[ConditionAND | ConditionOR] | None = field(default=None)
 
     def __post_init__(self) -> None:
         """Check detection validity."""
@@ -302,11 +292,11 @@ class SigmaDetection(ParentChainMixin):
     @classmethod
     def from_definition(
         cls,
-        definition: Union[
-            Mapping[str, Any], list[Union[int, float, str, bool, None]], int, float, str, bool, None
-        ],
-        source: Optional[SigmaRuleLocation] = None,
-    ) -> "SigmaDetection":
+        definition: (
+            Mapping[str, Any] | list[int | float | str | bool | None] | float | str | bool | None
+        ),
+        source: SigmaRuleLocation | None = None,
+    ) -> SigmaDetection:
         """Instantiate an appropriate SigmaDetection object from a parsed Sigma detection definition."""
         if isinstance(definition, Mapping):  # key-value-definition (case 1)
             return cls(
@@ -383,7 +373,7 @@ class SigmaDetection(ParentChainMixin):
                 # The following double loop (the second one is no real one, as it operates on a
                 # single element dict) merges keys (not fields!) into the merged dict.
                 for detection_item_converted in cast(
-                    list[SigmaDetectionPlainDict], detection_items
+                    "list[SigmaDetectionPlainDict]", detection_items
                 ):
                     for k, v in detection_item_converted.items():
                         if k not in merged_dict:  # key doesn't exists in merged dict: just add
@@ -396,7 +386,7 @@ class SigmaDetection(ParentChainMixin):
                                 ):  # make list from existing all-modified value if it's a plain value
                                     merged_dict[k] = [mk]
                                 mkl = cast(
-                                    SigmaDetectionPlainList, merged_dict[k]
+                                    "SigmaDetectionPlainList", merged_dict[k]
                                 )  # existing value is a list
 
                                 if isinstance(v, list):  # merging two and-linked lists is possible
@@ -430,7 +420,7 @@ class SigmaDetection(ParentChainMixin):
                                         mak, list
                                     ):  # ensure that existing 'all' key is a list
                                         merged_dict[ak] = [mak]
-                                    makl = cast(SigmaDetectionPlainList, merged_dict[ak])
+                                    makl = cast("SigmaDetectionPlainList", merged_dict[ak])
                                     makl.extend(vs)
                                 else:  # create new 'all' key from both existing keys
                                     merged_dict[ak] = vs
@@ -442,7 +432,9 @@ class SigmaDetection(ParentChainMixin):
                 }
             else:  # only lists and plain values, merge them into one list
                 merged_list: SigmaDetectionPlainList = list()
-                for detection_item_converted_list in cast(SigmaDetectionPlainList, detection_items):
+                for detection_item_converted_list in cast(
+                    "SigmaDetectionPlainList", detection_items
+                ):
                     if isinstance(
                         detection_item_converted_list, list
                     ):  # if item is a list, extend result list with it.
@@ -455,12 +447,10 @@ class SigmaDetection(ParentChainMixin):
 
     def postprocess(
         self,
-        detections: "SigmaDetections",
-        parent: Optional[Union["SigmaDetection", "SigmaDetectionItem", "ConditionItem"]] = None,
-        source: Optional[SigmaRuleLocation] = None,
-    ) -> Union[
-        "ConditionItem", "ConditionFieldEqualsValueExpression", "ConditionValueExpression", None
-    ]:
+        detections: SigmaDetections,
+        parent: SigmaDetection | SigmaDetectionItem | ConditionItem | None = None,
+        source: SigmaRuleLocation | None = None,
+    ) -> ConditionItem | ConditionFieldEqualsValueExpression | ConditionValueExpression | None:
         """Convert detection item into condition tree element"""
         super().postprocess(detections, parent, source)
         items = [
@@ -470,7 +460,7 @@ class SigmaDetection(ParentChainMixin):
         if len(items) == 1:  # no boolean linking required, directly return single element
             return items[0]
         elif len(items) > 1:
-            condition = cast(Union[Type[ConditionAND], Type[ConditionOR]], self.item_linking)(
+            condition = cast("type[ConditionAND | ConditionOR]", self.item_linking)(
                 items
             )  # case legitimate because post-init ensures that it's not None anymore.
             condition.postprocess(detections, parent, self.source)
@@ -478,7 +468,7 @@ class SigmaDetection(ParentChainMixin):
         else:  # Detection is empty, e.g. because DropDetectionItem transformation dropped everything.
             return None
 
-    def add_applied_processing_item(self, processing_item: Optional["ProcessingItemBase"]) -> None:
+    def add_applied_processing_item(self, processing_item: ProcessingItemBase | None) -> None:
         """Propagate processing item to all contained detection items."""
         for detection_item in self.detection_items:
             detection_item.add_applied_processing_item(processing_item)
@@ -490,7 +480,7 @@ class SigmaDetections:
 
     detections: dict[str, SigmaDetection]
     condition: list[str]
-    source: Optional[SigmaRuleLocation] = field(default=None, compare=False)
+    source: SigmaRuleLocation | None = field(default=None, compare=False)
 
     def __post_init__(self) -> None:
         """Detections sanity checks"""
@@ -506,8 +496,8 @@ class SigmaDetections:
 
     @classmethod
     def from_dict(
-        cls, detections: dict[str, Any], source: Optional[SigmaRuleLocation] = None
-    ) -> "SigmaDetections":
+        cls, detections: dict[str, Any], source: SigmaRuleLocation | None = None
+    ) -> SigmaDetections:
         try:
             if isinstance(detections["condition"], list):
                 condition = detections["condition"]
@@ -533,7 +523,7 @@ class SigmaDetections:
             identifier: detection.to_plain() for identifier, detection in self.detections.items()
         }
         if len(self.condition) > 1:
-            condition: Union[str, list[str]] = self.condition
+            condition: str | list[str] = self.condition
         else:
             condition = self.condition[0]
 

--- a/sigma/rule/rule.py
+++ b/sigma/rule/rule.py
@@ -1,12 +1,12 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field
-from typing import Optional, Any, cast
-from sigma.rule.base import SigmaRuleBase
-from sigma.processing.tracking import ProcessingItemTrackingMixin
+from typing import Any, cast
+
 import sigma.exceptions as sigma_exceptions
-from sigma.exceptions import (
-    SigmaRuleLocation,
-    SigmaError,
-)
+from sigma.exceptions import SigmaError, SigmaRuleLocation
+from sigma.processing.tracking import ProcessingItemTrackingMixin
+from sigma.rule.base import SigmaRuleBase
 from sigma.rule.detection import EmptySigmaDetections, SigmaDetections
 from sigma.rule.logsource import EmptyLogSource, SigmaLogSource
 
@@ -25,8 +25,8 @@ class SigmaRule(SigmaRuleBase, ProcessingItemTrackingMixin):
         cls,
         rule: dict[str, Any],
         collect_errors: bool = False,
-        source: Optional[SigmaRuleLocation] = None,
-    ) -> "SigmaRule":
+        source: SigmaRuleLocation | None = None,
+    ) -> SigmaRule:
         """
         Convert Sigma rule parsed in dict structure into SigmaRule object.
 
@@ -81,9 +81,9 @@ class SigmaRule(SigmaRuleBase, ProcessingItemTrackingMixin):
         )
 
     @classmethod
-    def from_yaml(cls, rule: str, collect_errors: bool = False) -> "SigmaRule":
+    def from_yaml(cls, rule: str, collect_errors: bool = False) -> SigmaRule:
         """Convert YAML input string with single document into SigmaRule object."""
-        return cast(SigmaRule, super().from_yaml(rule, collect_errors))
+        return cast("SigmaRule", super().from_yaml(rule, collect_errors))
 
     def to_dict(self) -> dict[str, Any]:
         """Convert rule object into dict."""

--- a/sigma/validators/base.py
+++ b/sigma/validators/base.py
@@ -1,9 +1,12 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, fields
 from enum import Enum, auto
-from typing import ClassVar, Optional, Set, Type, Union
-from sigma.rule import SigmaDetection, SigmaDetectionItem, SigmaRule, SigmaRuleBase, SigmaRuleTag
+from typing import ClassVar
+
 from sigma.correlations import SigmaCorrelationRule
+from sigma.rule import SigmaDetection, SigmaDetectionItem, SigmaRule, SigmaRuleBase, SigmaRuleTag
 from sigma.types import SigmaString, SigmaType
 
 
@@ -35,7 +38,7 @@ class SigmaValidationIssue(ABC):
 
     description: ClassVar[str] = "Sigma rule validation issue"
     severity: ClassVar[SigmaValidationIssueSeverity]
-    rules: list[Union[SigmaRule, SigmaCorrelationRule]]
+    rules: list[SigmaRule | SigmaCorrelationRule]
 
     def __post_init__(self) -> None:
         """Ensure that `self.rules` contains a list, even when a single rule was provided."""
@@ -69,7 +72,7 @@ class SigmaRuleValidator(ABC):
     """
 
     @abstractmethod
-    def validate(self, rule: Union[SigmaRule, SigmaCorrelationRule]) -> list[SigmaValidationIssue]:
+    def validate(self, rule: SigmaRule | SigmaCorrelationRule) -> list[SigmaValidationIssue]:
         """Implementation of the rule validation.
 
         :param rule: Sigma rule that should be validated.
@@ -105,7 +108,7 @@ class SigmaDetectionValidator(SigmaRuleValidator):
     effects in implementations of them methods mentioned above.
     """
 
-    def validate(self, rule: Union[SigmaRule, SigmaCorrelationRule]) -> list[SigmaValidationIssue]:
+    def validate(self, rule: SigmaRule | SigmaCorrelationRule) -> list[SigmaValidationIssue]:
         """
         Iterate over all detections and call validate_detection() for each.
         """
@@ -150,7 +153,7 @@ class SigmaDetectionItemValidator(SigmaDetectionValidator):
     """
 
     def validate_detection(
-        self, name: Optional[str], detection: SigmaDetection
+        self, name: str | None, detection: SigmaDetection
     ) -> list[SigmaValidationIssue]:
         """
         Iterate over all detection items of a detection definition and call
@@ -253,7 +256,7 @@ class SigmaTagValidator(SigmaRuleValidator):
     each tag.
     """
 
-    def validate(self, rule: Union[SigmaRule, SigmaCorrelationRule]) -> list[SigmaValidationIssue]:
+    def validate(self, rule: SigmaRule | SigmaCorrelationRule) -> list[SigmaValidationIssue]:
         super().validate(rule)
         return [issue for tag in rule.tags for issue in self.validate_tag(tag)]
 


### PR DESCRIPTION
* Update rules, filters, correlations and validators to leverage __future__.annotations:
  * Replace Union  with |
  * Replace Optional with | None
  * Replace Type with type
  * Remove quotes for types
  * organize imports with TYPE_CHECKING
* Remove unused imports
* Reorder imports with isort logic
* Add quotes for types when using cast

This is a subset of the changes from #377 