### PR TITLE
replace setParseAction by set_parse_action to fix deprecation warning

### DIFF
--- a/sigma/conditions.py
+++ b/sigma/conditions.py
@@ -316,12 +316,12 @@ class ConditionValueExpression(ParentChainMixin):
 
 
 identifier = Word(alphanums + "_-")
-identifier.setParseAction(ConditionIdentifier.from_parsed)
+identifier.set_parse_action(ConditionIdentifier.from_parsed)
 
 quantifier = Keyword("1") | Keyword("any") | Keyword("all")
 identifier_pattern = Word(alphanums + "*_")
 selector = quantifier + Keyword("of") + identifier_pattern
-selector.setParseAction(ConditionSelector.from_parsed)
+selector.set_parse_action(ConditionSelector.from_parsed)
 
 operand = selector | identifier
 condition = infix_notation(

--- a/sigma/processing/condition_expressions.py
+++ b/sigma/processing/condition_expressions.py
@@ -272,7 +272,7 @@ def parse_condition_expression(
     condition_expression: str,
 ) -> ConditionExpression:
     identifier = Word(alphanums + "_-")
-    identifier.setParseAction(ConditionIdentifier.from_parsed)
+    identifier.set_parse_action(ConditionIdentifier.from_parsed)
     condition_parser = infix_notation(
         identifier,
         [


### PR DESCRIPTION
Fix the deprecation warning `##[warning]'setParseAction' deprecated - use 'set_parse_action'` according to the documentation [pyparsing API — PyParsing 3.2.5 documentation](https://pyparsing-docs.readthedocs.io/en/latest/pyparsing.html#pyparsing.ParserElement.setParseAction)