### PR TITLE
Add macOS ESF and Unified Logging pipelines

### DIFF
--- a/pipelines/macos_esf.yml
+++ b/pipelines/macos_esf.yml
@@ -1,0 +1,242 @@
+name: macos-esf
+priority: 100
+transformations:
+  - type: field_name_mapping
+    mapping:
+      # Process fields - standard Sigma fields for process_creation
+      Image: Image
+      CommandLine: CommandLine
+      ProcessId: ProcessId
+      ParentProcessId: ParentProcessId
+      ParentImage: ParentImage
+      OriginalFileName: OriginalFileName
+      CurrentDirectory: CurrentDirectory
+      
+      # User fields
+      User: User
+      UserId: UserId
+      user.name: User
+      user.id: UserId
+      user.effective.id: user.effective.id
+      user.effective.name: user.effective.name
+      user.real.id: user.real.id
+      user.real.name: user.real.name
+      user.saved.id: user.saved.id
+      user.saved.name: user.saved.name
+      EffectiveUserId: EffectiveUserId
+      RealUserId: RealUserId
+      TargetUser: TargetUser
+      TargetUserId: TargetUserId
+      TargetGroup: TargetGroup
+      TargetGroupId: TargetGroupId
+      
+      # Group fields
+      group.effective.id: group.effective.id
+      group.effective.name: group.effective.name
+      group.real.id: group.real.id
+      group.real.name: group.real.name
+      group.saved.id: group.saved.id
+      group.saved.name: group.saved.name
+      EffectiveGroupId: EffectiveGroupId
+      RealGroupId: RealGroupId
+      
+      # File event fields - standard Sigma fields
+      TargetFilename: TargetFilename
+      SourceFilename: SourceFilename
+      DestinationFilename: DestinationFilename
+      file.path: TargetFilename
+      target.file.path: TargetFilename
+      source.file.path: SourceFilename
+      destination.file.path: DestinationFilename
+      target.path: TargetFilename
+      source.path: SourceFilename
+      destination.path: DestinationFilename
+      
+      # Network fields
+      DestinationIp: DestinationIp
+      DestinationPort: DestinationPort
+      SourceIp: SourceIp
+      SourcePort: SourcePort
+      destination.ip: DestinationIp
+      destination.port: DestinationPort
+      source.ip: SourceIp
+      source.port: SourcePort
+      
+      # Event metadata
+      event_type: event_type
+      event_name: event_name
+      
+      # Authentication fields
+      auth.username: User
+      auth.type: auth.type
+      auth.success: auth.success
+      
+      # Code signing fields
+      code_signature.team_id: code_signature.team_id
+      code_signature.status: code_signature.status
+      process.signing_id: code_signature.signing_id
+      
+      # TCC/Privacy fields
+      tcc.service: tcc.service
+      tcc.client: tcc.client
+      
+      # XProtect fields
+      xprotect.signature: xprotect.signature
+      
+      # Mount fields
+      mount.path: mount.path
+      mount.type: mount.type
+      
+      # Kernel extension fields
+      kext.identifier: kext.identifier
+      kext.path: kext.path
+      kext.team_id: kext.team_id
+      
+      # Signal fields
+      signal.number: signal.number
+      signal.target_pid: target.process.pid
+      target.process.pid: target.process.pid
+      target.process.path: target.process.path
+      
+      # XPC fields
+      xpc.service_name: xpc.service_name
+      xpc.pid: xpc.pid
+      
+      # Exit fields
+      exit.stat: exit.stat
+      
+      # Memory protection fields (mprotect)
+      mprotect.protection: mprotect.protection
+      mprotect.prot: mprotect.prot
+      mprotect.max_protection: mprotect.max_protection
+      event.mmap.protection: mprotect.protection
+      event.mmap.max_protection: mprotect.max_protection
+      event.mprotect.protection: mprotect.protection
+      event.mprotect.prot: mprotect.prot
+
+logsources:
+  # Main ESF log source
+  macos_esf:
+    product: macos
+    service: endpointsecurity
+    category: process_creation
+    
+  # Process creation - ES_EVENT_TYPE_NOTIFY_EXEC (9)
+  process_creation:
+    product: macos
+    service: endpointsecurity
+    category: process_creation
+    conditions:
+      event_type: 9
+      event_name: exec
+      
+  # File events
+  file_event:
+    product: macos
+    service: endpointsecurity
+    category: file_event
+    conditions:
+      event_type:
+        - 10  # OPEN
+        - 13  # CREATE
+        - 14  # WRITE
+        - 15  # CLOSE
+        - 21  # RENAME
+        - 20  # UNLINK
+        
+  # File creation
+  file_create:
+    product: macos
+    service: endpointsecurity
+    category: file_event
+    conditions:
+      event_type: 13
+      event_name: create
+      
+  # File deletion
+  file_delete:
+    product: macos
+    service: endpointsecurity
+    category: file_event
+    conditions:
+      event_type: 20
+      event_name: unlink
+      
+  # File rename
+  file_rename:
+    product: macos
+    service: endpointsecurity
+    category: file_event
+    conditions:
+      event_type: 21
+      event_name: rename
+      
+  # Authentication events
+  authentication:
+    product: macos
+    service: endpointsecurity
+    category: authentication
+    conditions:
+      event_type: 111
+      event_name: authentication
+      
+  # Privilege escalation
+  privilege_escalation:
+    product: macos
+    service: endpointsecurity
+    category: privilege_escalation
+    conditions:
+      event_type:
+        - 24  # SETUID
+        - 25  # SETGID
+        
+  # Process injection
+  process_injection:
+    product: macos
+    service: endpointsecurity
+    category: process_injection
+    conditions:
+      event_type: 64
+      event_name: ptrace
+      
+  # Kernel extension load
+  kernel_extension:
+    product: macos
+    service: endpointsecurity
+    category: kernel_extension
+    conditions:
+      event_type:
+        - 17  # KEXTLOAD
+        - 18  # KEXTUNLOAD
+        
+  # Code signature invalidation
+  codesigning:
+    product: macos
+    service: endpointsecurity
+    category: codesigning
+    conditions:
+      event_type:
+        - 62   # CS_INVALIDATED (old)
+        - 94   # CS_INVALIDATED (new)
+        
+  # Security policy events
+  security_policy:
+    product: macos
+    service: endpointsecurity
+    category: security_policy
+    conditions:
+      event_type:
+        - 112  # XP_MALWARE_DETECTED
+        - 113  # XP_MALWARE_REMEDIATED
+        - 146  # GATEKEEPER_USER_OVERRIDE
+        - 147  # TCC_MODIFY
+        
+  # Mount events
+  mount:
+    product: macos
+    service: endpointsecurity
+    category: mount
+    conditions:
+      event_type: 22
+      event_name: mount
+

--- a/pipelines/macos_ul.yml
+++ b/pipelines/macos_ul.yml
@@ -1,0 +1,125 @@
+name: macos-ul
+priority: 100
+transformations:
+  - type: field_name_mapping
+    mapping:
+      # Unified Logging core fields
+      subsystem: subsystem
+      category: category
+      message: message
+      
+      # Process fields - map to standard Sigma
+      ProcessName: ProcessName
+      ProcessId: ProcessId
+      process: ProcessName
+      pid: ProcessId
+      
+      # Command line - extracted from message
+      CommandLine: CommandLine
+      message: CommandLine
+      
+      # User fields
+      User: User
+      Username: User
+      user.name: User
+      
+      # Network fields (extracted from message)
+      DestinationIp: DestinationIp
+      DestinationPort: DestinationPort
+      SourceIp: SourceIp
+      SourcePort: SourcePort
+      
+      # Host and system
+      hostname: host.name
+      host.name: host.name
+
+logsources:
+  # Main Unified Logging source
+  macos_ul:
+    product: macos
+    service: unifiedlog
+    
+  # TCC (Transparency, Consent, and Control) events
+  tcc:
+    product: macos
+    service: unifiedlog
+    category: tcc
+    conditions:
+      subsystem: com.apple.TCC
+      
+  # Gatekeeper events
+  gatekeeper:
+    product: macos
+    service: unifiedlog
+    category: gatekeeper
+    conditions:
+      subsystem:
+        - com.apple.security.assessment
+        - com.apple.gatekeeper
+        
+  # Sudo events
+  sudo:
+    product: macos
+    service: unifiedlog
+    category: sudo
+    conditions:
+      subsystem: com.apple.sudo
+      
+  # Authentication events
+  authentication:
+    product: macos
+    service: unifiedlog
+    category: authentication
+    conditions:
+      subsystem:
+        - com.apple.authorization
+        - com.apple.opendirectoryd
+        - com.apple.securityd
+        
+  # Code signing events
+  codesigning:
+    product: macos
+    service: unifiedlog
+    category: codesigning
+    conditions:
+      subsystem: com.apple.securityd
+      
+  # Security policy events
+  security_policy:
+    product: macos
+    service: unifiedlog
+    category: security_policy
+    conditions:
+      subsystem:
+        - com.apple.syspolicy
+        - com.apple.xprotect
+        - com.apple.MRT
+        
+  # Firewall events
+  firewall:
+    product: macos
+    service: unifiedlog
+    category: firewall
+    conditions:
+      subsystem:
+        - com.apple.alf
+        - com.apple.socketfilterfw
+        
+  # Network events
+  network:
+    product: macos
+    service: unifiedlog
+    category: network
+    conditions:
+      subsystem:
+        - com.apple.network
+        - com.apple.networking
+        
+  # Kernel events
+  kernel:
+    product: macos
+    service: unifiedlog
+    category: kernel
+    conditions:
+      subsystem: com.apple.kernel
+


### PR DESCRIPTION
This PR adds expanded pipeline support for macOS Endpoint Security Framework (ESF) and Unified Logging (UL) telemetry.

## Features

### ESF Pipeline (`macos_esf.yml`)
- Support for 23 ESF event types including:
  - Process events (exec, fork, exit)
  - File events (open, create, rename, unlink, close, write)
  - Memory events (mprotect - filtered to W+X for code injection detection)
  - Kernel extension events (kextload, kextunload)
  - Security events (signal, xpc_connect, authentication)
  - Security policy events (xprotect, tcc, gatekeeper)

### UL Pipeline (`macos_ul.yml`)
- Support for 12 UL subsystems including:
  - TCC (Transparency, Consent, and Control)
  - Gatekeeper
  - Sudo
  - Authentication
  - Code signing
  - Security policy
  - Firewall
  - Network

## Field Mappings

Both pipelines map to standard Sigma field names:
- Process: `Image`, `CommandLine`, `ProcessId`, `ParentProcessId`
- File: `TargetFilename`, `SourceFilename`, `DestinationFilename`
- User: `User`, `UserId`, `user.effective.*`, `user.real.*`, `user.saved.*`
- Event metadata: `event_type`, `event_name`

## Compatibility

- Uses standard pySigma YAML pipeline format
- Compatible with standard `ElasticsearchLuceneBackend`
- No custom backend modifications required
- Follows existing Windows/Linux pipeline patterns
- Uses `event_type` in conditions (similar to Windows `EventID` and Linux `syscall`)
- Standard log source categories and field mappings

## Testing

Pipelines have been tested with 50 new Sigma rules, including:
- Unsigned Kernel Extension Load (CRITICAL)
- SIGKILL Sent to Security Tools (HIGH)
- XProtect Malware Detection (CRITICAL)
- UL Quarantine/XProtect Detection (HIGH)

All rules successfully convert to Elasticsearch queries and match test events.

## Related

Related rules will be submitted in separate PRs to `SigmaHQ/sigma` if these pipelines are accepted amongst the Sigma team and community.