### PR TITLE
Deprecate ExceptionOnUsage

### DIFF
--- a/sigma/conversion/base.py
+++ b/sigma/conversion/base.py
@@ -2641,23 +2641,20 @@ class TextQueryBackend(Backend):
 
     def convert_referenced_rules(
         self, referenced_rules: list[SigmaRuleReference], method: str
-    ) -> str:
+    ) -> str | None:
         if (
             self.referenced_rules_expression is None
             or self.referenced_rules_expression_joiner is None
         ):
-            raise SigmaBackendError(
-                "Backend doesn't define referenced rule expression but uses it in correlation query template"
-            )
-        else:
-            return self.referenced_rules_expression_joiner[method].join(
-                (
-                    self.referenced_rules_expression[method].format(
-                        ruleid=rule_reference.rule.name or rule_reference.rule.id
-                    )
-                    for rule_reference in referenced_rules
+            return None
+        return self.referenced_rules_expression_joiner[method].join(
+            (
+                self.referenced_rules_expression[method].format(
+                    ruleid=rule_reference.rule.name or rule_reference.rule.id
                 )
+                for rule_reference in referenced_rules
             )
+        )
 
     # Implementation of the condition phase of the correlation query.
     def convert_correlation_condition_from_template(

--- a/sigma/conversion/base.py
+++ b/sigma/conversion/base.py
@@ -34,7 +34,6 @@ from sigma.correlations import (
     SigmaRuleReference,
 )
 from sigma.exceptions import (
-    ExceptionOnUsage,
     SigmaBackendError,
     SigmaConversionError,
     SigmaError,
@@ -2644,10 +2643,8 @@ class TextQueryBackend(Backend):
             self.referenced_rules_expression is None
             or self.referenced_rules_expression_joiner is None
         ):
-            return ExceptionOnUsage(  # type: ignore
-                SigmaBackendError(
-                    "Backend doesn't defines referenced rule expression but uses it in correlation query template"
-                )
+            raise SigmaBackendError(
+                "Backend doesn't defines referenced rule expression but uses it in correlation query template"
             )
         else:
             return self.referenced_rules_expression_joiner[method].join(

--- a/sigma/conversion/base.py
+++ b/sigma/conversion/base.py
@@ -1,9 +1,10 @@
 import re
+import string
 from abc import ABC, abstractmethod
 from collections import ChainMap, defaultdict
 from contextlib import contextmanager
-from typing import Any, Callable, ClassVar, Iterator, cast
 from itertools import pairwise
+from typing import Any, Callable, ClassVar, Iterator, cast
 
 from typing_extensions import Self
 
@@ -33,12 +34,7 @@ from sigma.correlations import (
     SigmaExtendedCorrelationCondition,
     SigmaRuleReference,
 )
-from sigma.exceptions import (
-    SigmaBackendError,
-    SigmaConversionError,
-    SigmaError,
-    SigmaValueError,
-)
+from sigma.exceptions import SigmaBackendError, SigmaConversionError, SigmaError, SigmaValueError
 from sigma.processing.pipeline import ProcessingPipeline
 from sigma.rule import SigmaRule
 from sigma.rule.detection import SigmaDetection, SigmaDetectionItem
@@ -317,6 +313,33 @@ class Backend(ABC):
             else:
                 e.args = (e.args[0] + msg,)
             raise
+
+    def _format_template(
+        self: Self, template: str, **kwargs: str | int | list[str] | SigmaCorrelationRule | None
+    ) -> str:
+        """
+        Ensure all template's variables are properly populated before generating the output.
+
+        :param template: Templated string to format.
+        :type cond: str
+        :param kwargs: List of parameters to populate the template.
+        :type kwargs: str | int | list[str] | SigmaCorrelationRule | None
+        :return: Templated string
+        :rtype: str
+        """
+        variables: list[tuple[str, str | int | list[str] | SigmaCorrelationRule | None]] = [
+            (parsed_template[1], kwargs.get(parsed_template[1]))
+            for parsed_template in string.Formatter().parse(template)
+            if parsed_template[1]
+        ]
+
+        for variable_name, variable_value in variables:
+            if variable_name == "referenced_rules" and variable_value is None:
+                raise SigmaBackendError(
+                    "Backend doesn't define referenced rule expression but uses it in correlation query template"
+                )
+
+        return template.format(**kwargs)
 
     def decide_convert_condition_as_in_expression(
         self, cond: ConditionOR | ConditionAND, state: ConversionState
@@ -2551,7 +2574,8 @@ class TextQueryBackend(Backend):
             )
 
         template = templates[method]
-        return template.format(
+        return self._format_template(
+            template,
             rule=rule,
             referenced_rules=self.convert_referenced_rules(rule.referenced_rules, method),
             field=(
@@ -2673,7 +2697,8 @@ class TextQueryBackend(Backend):
 
         # Only basic conditions have these attributes
         if isinstance(cond, SigmaCorrelationCondition):
-            return template.format(
+            return self._format_template(
+                template,
                 field=cond.fieldref,
                 op=self.correlation_condition_mapping[cond.op],
                 count=cond.count,
@@ -2682,7 +2707,8 @@ class TextQueryBackend(Backend):
         else:
             # Extended conditions - convert parse tree to query expression
             extended_condition = self.convert_extended_correlation_condition(cond.parsed, method)
-            return template.format(
+            return self._format_template(
+                template,
                 extended_condition=extended_condition,
                 referenced_rules=self.convert_referenced_rules(referenced_rules, method),
             )

--- a/sigma/conversion/base.py
+++ b/sigma/conversion/base.py
@@ -2644,7 +2644,7 @@ class TextQueryBackend(Backend):
             or self.referenced_rules_expression_joiner is None
         ):
             raise SigmaBackendError(
-                "Backend doesn't defines referenced rule expression but uses it in correlation query template"
+                "Backend doesn't define referenced rule expression but uses it in correlation query template"
             )
         else:
             return self.referenced_rules_expression_joiner[method].join(

--- a/sigma/exceptions.py
+++ b/sigma/exceptions.py
@@ -1,6 +1,7 @@
+import warnings
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Optional
 
 if TYPE_CHECKING:
     from sigma.rule import SigmaRuleBase
@@ -395,4 +396,8 @@ class ExceptionOnUsage:
     exception: Exception
 
     def __getattribute__(self, item: str) -> Any:
+        deprecation_message: str = (
+            f"{type(self).__name__} is deprecated and will be removed in a future release."
+        )
+        warnings.warn(deprecation_message, DeprecationWarning)
         raise object.__getattribute__(self, "exception")

--- a/tests/test_conversion_correlations.py
+++ b/tests/test_conversion_correlations.py
@@ -63,11 +63,9 @@ def test_generate_query_without_referenced_rules_expression(
 ):
     monkeypatch.setattr(test_backend, "referenced_rules_expression", None)
     monkeypatch.setattr(test_backend, "referenced_rules_expression_joiner", None)
-    with pytest.raises(
-        SigmaBackendError,
-        match="Backend doesn't define referenced rule expression but uses it in correlation query template",
-    ):
-        test_backend.convert(event_count_correlation_rule)
+    assert test_backend.convert(event_count_correlation_rule) == ["""EventID=4625
+| aggregate window=5min count() as event_count by TargetUserName, TargetDomainName, mappedB
+| where event_count >= 10"""]
 
 
 def test_event_count_correlation_single_rule_with_fields(

--- a/tests/test_conversion_correlations.py
+++ b/tests/test_conversion_correlations.py
@@ -63,9 +63,11 @@ def test_generate_query_without_referenced_rules_expression(
 ):
     monkeypatch.setattr(test_backend, "referenced_rules_expression", None)
     monkeypatch.setattr(test_backend, "referenced_rules_expression_joiner", None)
-    assert test_backend.convert(event_count_correlation_rule) == ["""EventID=4625
-| aggregate window=5min count() as event_count by TargetUserName, TargetDomainName, mappedB
-| where event_count >= 10"""]
+    with pytest.raises(
+        SigmaBackendError,
+        match="Backend doesn't define referenced rule expression but uses it in correlation query template",
+    ):
+        test_backend.convert(event_count_correlation_rule)
 
 
 def test_event_count_correlation_single_rule_with_fields(

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,7 +1,9 @@
-from pathlib import Path
 import re
+from pathlib import Path
+
 import pytest
-from sigma.exceptions import SigmaDetectionError, SigmaRuleLocation, SigmaError
+
+from sigma.exceptions import ExceptionOnUsage, SigmaDetectionError, SigmaError, SigmaRuleLocation
 
 
 @pytest.fixture
@@ -67,3 +69,13 @@ def test_exception_unequalness_different_type():
 
 def test_exception_unequalness_incompatible_type():
     assert SigmaDetectionError("A") != ValueError("A")
+
+
+def test_exception_on_usage() -> None:
+    test_exception_message: str = "some message"
+    test_exception: ValueError = ValueError(test_exception_message)
+    e: ExceptionOnUsage = ExceptionOnUsage(test_exception)
+    with pytest.deprecated_call(
+        match=r"\w+ is deprecated and will be removed in a future release."
+    ), pytest.raises(ValueError, match=test_exception_message):
+        e.test


### PR DESCRIPTION
* Add deprecation warning for ExceptionOnUsage
* Remove calls to ExceptionOnUsage
* Add test to validate deprecation warning being raised
* Update test_generate_query_without_referenced_rules_expression to capture raised exception due to new behavior