### PR TITLE
Add security measures for vars execution in TemplateBase

### DIFF
--- a/sigma/exceptions.py
+++ b/sigma/exceptions.py
@@ -190,6 +190,12 @@ class SigmaRegularExpressionError(SigmaValueError):
     pass
 
 
+class SigmaSecurityError(SigmaError):
+    """Security-sensitive operation was attempted without explicit opt-in."""
+
+    pass
+
+
 class SigmaTransformationError(SigmaError):
     """Error while transformation. Can be raised intentionally by FailureTransformation."""
 

--- a/sigma/processing/finalization.py
+++ b/sigma/processing/finalization.py
@@ -109,16 +109,38 @@ class NestedFinalizer(Finalizer):
         self._nested_pipeline = ProcessingPipeline(finalizers=self.finalizers)
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> "NestedFinalizer":
+    def from_dict(
+        cls,
+        d: dict[str, Any],
+        allow_template_vars: bool = False,
+        vars_allowed_paths: tuple[str, ...] | None = None,
+    ) -> "NestedFinalizer":
         if "finalizers" not in d:
             raise SigmaConfigurationError("Nested finalizer requires a 'finalizers' key.")
         fs = []
         for finalizer in d["finalizers"]:
+            finalizer.pop("allow_template_vars", None)  # Strip untrusted YAML value
+            finalizer.pop("vars_allowed_paths", None)  # Strip untrusted YAML value
             try:
                 finalizer_type = finalizer.pop("type")
             except KeyError:
                 raise SigmaConfigurationError("Finalizer type not specified for: " + str(finalizer))
-            fs.append(finalizers[finalizer_type].from_dict(finalizer))
+
+            finalizer_cls = finalizers[finalizer_type]
+            if issubclass(finalizer_cls, TemplateBase):
+                finalizer["allow_template_vars"] = allow_template_vars
+                finalizer["vars_allowed_paths"] = vars_allowed_paths
+                fs.append(finalizer_cls.from_dict(finalizer))
+            elif finalizer_cls is cls:
+                fs.append(
+                    finalizer_cls.from_dict(
+                        finalizer,
+                        allow_template_vars=allow_template_vars,
+                        vars_allowed_paths=vars_allowed_paths,
+                    )
+                )
+            else:
+                fs.append(finalizer_cls.from_dict(finalizer))
         return cls(finalizers=fs)
 
     def apply(self, queries: list[Any]) -> Any:

--- a/sigma/processing/finalization.py
+++ b/sigma/processing/finalization.py
@@ -117,7 +117,7 @@ class NestedFinalizer(Finalizer):
     ) -> "NestedFinalizer":
         if "finalizers" not in d:
             raise SigmaConfigurationError("Nested finalizer requires a 'finalizers' key.")
-        fs = []
+        fs: list[Finalizer] = []
         for finalizer in d["finalizers"]:
             finalizer.pop("allow_template_vars", None)  # Strip untrusted YAML value
             finalizer.pop("vars_allowed_paths", None)  # Strip untrusted YAML value
@@ -133,7 +133,7 @@ class NestedFinalizer(Finalizer):
                 fs.append(finalizer_cls.from_dict(finalizer))
             elif finalizer_cls is cls:
                 fs.append(
-                    finalizer_cls.from_dict(
+                    cls.from_dict(
                         finalizer,
                         allow_template_vars=allow_template_vars,
                         vars_allowed_paths=vars_allowed_paths,

--- a/sigma/processing/pipeline.py
+++ b/sigma/processing/pipeline.py
@@ -807,7 +807,7 @@ class ProcessingPipeline:
                 raise SigmaConfigurationError(f"Error in processing rule {i + 1}: {str(e)}") from e
 
         fds = d.get("finalizers", list())  # no default transformation
-        fs = list()
+        fs: list[Finalizer] = list()
         for fd in fds:
             fd.pop("allow_template_vars", None)  # Strip untrusted YAML value
             fd.pop("vars_allowed_paths", None)  # Strip untrusted YAML value
@@ -829,7 +829,7 @@ class ProcessingPipeline:
                 fs.append(finalizer_cls.from_dict(fd))
             elif finalizer_cls is NestedFinalizer:
                 fs.append(
-                    finalizer_cls.from_dict(
+                    NestedFinalizer.from_dict(
                         fd,
                         allow_template_vars=allow_template_vars,
                         vars_allowed_paths=vars_allowed_paths,

--- a/sigma/processing/pipeline.py
+++ b/sigma/processing/pipeline.py
@@ -865,7 +865,9 @@ class ProcessingPipeline:
         except yaml.parser.ParserError as e:
             raise SigmaPipelineParsingError("Error in parsing of a Sigma processing pipeline")
         return cls.from_dict(
-            parsed_pipeline, allow_template_vars=allow_template_vars, vars_allowed_paths=vars_allowed_paths
+            parsed_pipeline,
+            allow_template_vars=allow_template_vars,
+            vars_allowed_paths=vars_allowed_paths,
         )
 
     def apply(self, rule: SigmaRule | SigmaCorrelationRule) -> SigmaRule | SigmaCorrelationRule:

--- a/sigma/processing/pipeline.py
+++ b/sigma/processing/pipeline.py
@@ -20,7 +20,8 @@ from typing import (
 
 from sigma.processing.condition_expressions import ConditionExpression, parse_condition_expression
 from sigma.processing.conditions.base import ProcessingCondition
-from sigma.processing.finalization import Finalizer, finalizers
+from sigma.processing.finalization import Finalizer, NestedFinalizer, finalizers
+from sigma.processing.templates import TemplateBase
 from sigma.processing.tracking import FieldMappingTracking
 from sigma.processing.transformations import transformations
 from sigma.rule import SigmaDetectionItem, SigmaRule
@@ -67,7 +68,11 @@ class ProcessingItemBase:
 
     @classmethod
     def _base_args_from_dict(
-        cls, d: dict[str, Any], transformations: dict[str, Type[Transformation]]
+        cls,
+        d: dict[str, Any],
+        transformations: dict[str, Type[Transformation]],
+        allow_template_vars: bool = False,
+        vars_allowed_paths: tuple[str, ...] | None = None,
     ) -> dict[str, Any]:
         """Return class instantiation parameters for attributes contained in base class for further
         usage in similar methods of classes inherited from this class."""
@@ -92,7 +97,12 @@ class ProcessingItemBase:
             "rule_condition_expression": rule_cond_expr,
             "rule_condition_linking": cls._parse_condition_linking(d, "rule_cond_op"),
             "rule_condition_negation": d.get("rule_cond_not", False),
-            "transformation": cls._instantiate_transformation(d, transformations),
+            "transformation": cls._instantiate_transformation(
+                d,
+                transformations,
+                allow_template_vars=allow_template_vars,
+                vars_allowed_paths=vars_allowed_paths,
+            ),
         }
 
     def _check_conditions(
@@ -291,7 +301,11 @@ class ProcessingItemBase:
 
     @classmethod
     def _instantiate_transformation(
-        cls, d: dict[str, Any], transformations: dict[str, Type[Transformation]]
+        cls,
+        d: dict[str, Any],
+        transformations: dict[str, Type[Transformation]],
+        allow_template_vars: bool = False,
+        vars_allowed_paths: tuple[str, ...] | None = None,
     ) -> Transformation:
         try:
             transformation_class_name = d["type"]
@@ -324,8 +338,13 @@ class ProcessingItemBase:
                 "field_name_cond_not",
                 "type",
                 "id",
+                "allow_template_vars",
+                "vars_allowed_paths",
             }
         }
+        if issubclass(transformation_class, TemplateBase):
+            params["allow_template_vars"] = allow_template_vars
+            params["vars_allowed_paths"] = vars_allowed_paths
         try:
             return transformation_class(**params)
         except (SigmaConfigurationError, TypeError) as e:
@@ -626,10 +645,18 @@ class QueryPostprocessingItem(ProcessingItemBase):
     transformation: QueryPostprocessingTransformation
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> "QueryPostprocessingItem":
+    def from_dict(
+        cls,
+        d: dict[str, Any],
+        allow_template_vars: bool = False,
+        vars_allowed_paths: tuple[str, ...] | None = None,
+    ) -> "QueryPostprocessingItem":
         """Instantiate processing item from parsed definition and variables."""
         kwargs = super()._base_args_from_dict(
-            d, cast(dict[str, Type[Transformation]], query_postprocessing_transformations)
+            d,
+            cast(dict[str, Type[Transformation]], query_postprocessing_transformations),
+            allow_template_vars=allow_template_vars,
+            vars_allowed_paths=vars_allowed_paths,
         )
         return cls(**kwargs)
 
@@ -729,7 +756,12 @@ class ProcessingPipeline:
             finalizer._pipeline = None
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> "ProcessingPipeline":
+    def from_dict(
+        cls,
+        d: dict[str, Any],
+        allow_template_vars: bool = False,
+        vars_allowed_paths: tuple[str, ...] | None = None,
+    ) -> "ProcessingPipeline":
         """Instantiate processing pipeline from a parsed processing item description."""
 
         custom_keys = [
@@ -764,13 +796,21 @@ class ProcessingPipeline:
         postprocessing_items = list()
         for i, item in enumerate(items):
             try:
-                postprocessing_items.append(QueryPostprocessingItem.from_dict(item))
+                postprocessing_items.append(
+                    QueryPostprocessingItem.from_dict(
+                        item,
+                        allow_template_vars=allow_template_vars,
+                        vars_allowed_paths=vars_allowed_paths,
+                    )
+                )
             except SigmaConfigurationError as e:
                 raise SigmaConfigurationError(f"Error in processing rule {i + 1}: {str(e)}") from e
 
         fds = d.get("finalizers", list())  # no default transformation
         fs = list()
         for fd in fds:
+            fd.pop("allow_template_vars", None)  # Strip untrusted YAML value
+            fd.pop("vars_allowed_paths", None)  # Strip untrusted YAML value
             try:
                 finalizer_type = fd.pop("type")
             except KeyError:
@@ -779,9 +819,24 @@ class ProcessingPipeline:
                 )
 
             try:
-                fs.append(finalizers[finalizer_type].from_dict(fd))
+                finalizer_cls = finalizers[finalizer_type]
             except KeyError:
                 raise SigmaConfigurationError(f"Finalizer '{finalizer_type}' is unknown")
+
+            if issubclass(finalizer_cls, TemplateBase):
+                fd["allow_template_vars"] = allow_template_vars
+                fd["vars_allowed_paths"] = vars_allowed_paths
+                fs.append(finalizer_cls.from_dict(fd))
+            elif finalizer_cls is NestedFinalizer:
+                fs.append(
+                    finalizer_cls.from_dict(
+                        fd,
+                        allow_template_vars=allow_template_vars,
+                        vars_allowed_paths=vars_allowed_paths,
+                    )
+                )
+            else:
+                fs.append(finalizer_cls.from_dict(fd))
 
         priority = d.get("priority", 0)
         name = d.get("name", None)
@@ -798,13 +853,20 @@ class ProcessingPipeline:
         )
 
     @classmethod
-    def from_yaml(cls, processing_pipeline: str) -> "ProcessingPipeline":
+    def from_yaml(
+        cls,
+        processing_pipeline: str,
+        allow_template_vars: bool = False,
+        vars_allowed_paths: tuple[str, ...] | None = None,
+    ) -> "ProcessingPipeline":
         """Convert YAML input string into processing pipeline."""
         try:
             parsed_pipeline = yaml.safe_load(processing_pipeline)
         except yaml.parser.ParserError as e:
             raise SigmaPipelineParsingError("Error in parsing of a Sigma processing pipeline")
-        return cls.from_dict(parsed_pipeline)
+        return cls.from_dict(
+            parsed_pipeline, allow_template_vars=allow_template_vars, vars_allowed_paths=vars_allowed_paths
+        )
 
     def apply(self, rule: SigmaRule | SigmaCorrelationRule) -> SigmaRule | SigmaCorrelationRule:
         """Apply processing pipeline on Sigma rule."""

--- a/sigma/processing/templates.py
+++ b/sigma/processing/templates.py
@@ -1,9 +1,14 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import importlib.util
+import os
 import sys
 from typing import Any, Dict
 
 from jinja2 import Environment, FileSystemLoader, Template
+
+from sigma.exceptions import SigmaSecurityError
+
+PYSIGMA_ALLOW_VARS_EXECUTION_ENV = "PYSIGMA_ALLOW_VARS_EXECUTION"
 
 
 @dataclass
@@ -13,6 +18,15 @@ class TemplateBase:
     If *vars* is provided, it should point to a Python file containing helper functions
     and variables to be made available in the Jinja2 template context. The Python file
     should define a dictionary named 'vars' containing the functions/variables to export.
+
+    **Security warning:** The *vars* feature executes arbitrary Python code from the
+    specified file. It is disabled by default and must be explicitly enabled via the
+    *allow_template_vars* parameter or by setting the environment variable
+    ``PYSIGMA_ALLOW_VARS_EXECUTION=1``.
+
+    When enabled, the resolved vars file path is checked against *vars_allowed_paths*.
+    The file must reside under (or in a subdirectory of) one of the listed base
+    directories. If *vars_allowed_paths* is ``None`` no path restriction is applied.
 
     Example Python vars file:
         def format_price(amount, currency='€'):
@@ -27,6 +41,8 @@ class TemplateBase:
     path: str | None = None
     autoescape: bool = False
     vars: str | None = None
+    allow_template_vars: bool = False
+    vars_allowed_paths: tuple[str, ...] | None = None
 
     def __post_init__(self) -> None:
         if self.path is None:
@@ -38,8 +54,21 @@ class TemplateBase:
 
         # Load custom variables/functions from Python file if provided
         if self.vars is not None:
+            if not self._vars_execution_allowed():
+                raise SigmaSecurityError(
+                    "The 'vars' feature executes Python code from an external file and is "
+                    "disabled by default for security reasons. To enable it, pass "
+                    "allow_template_vars=True when constructing the pipeline or set the environment "
+                    f"variable {PYSIGMA_ALLOW_VARS_EXECUTION_ENV}=1."
+                )
             custom_vars = self._load_vars_from_file(self.vars)
             self.j2template.globals.update(custom_vars)
+
+    def _vars_execution_allowed(self) -> bool:
+        """Check if vars execution is allowed via parameter or environment variable."""
+        if self.allow_template_vars:
+            return True
+        return os.environ.get(PYSIGMA_ALLOW_VARS_EXECUTION_ENV, "").lower() in ("1", "true")
 
     def _load_vars_from_file(self, vars_path: str) -> Any:
         """Load variables and functions from a Python file.
@@ -50,6 +79,19 @@ class TemplateBase:
         :param vars_path: Path to the Python file
         :return: Dictionary of variables to add to template globals
         """
+        vars_path = os.path.realpath(vars_path)
+
+        if self.vars_allowed_paths is not None:
+            if not any(
+                vars_path.startswith(os.path.realpath(base) + os.sep)
+                or vars_path == os.path.realpath(base)
+                for base in self.vars_allowed_paths
+            ):
+                raise SigmaSecurityError(
+                    f"Vars file '{vars_path}' is outside the allowed base directories: "
+                    f"{', '.join(os.path.realpath(p) for p in self.vars_allowed_paths)}"
+                )
+
         try:
             spec = importlib.util.spec_from_file_location("template_vars", vars_path)
         except (FileNotFoundError, OSError) as e:
@@ -58,13 +100,16 @@ class TemplateBase:
         if spec is None or spec.loader is None:
             raise ValueError(f"Could not load vars file: {vars_path}")
 
+        module_name = f"_pysigma_template_vars_{id(spec)}"
         module = importlib.util.module_from_spec(spec)
-        sys.modules["template_vars"] = module
+        sys.modules[module_name] = module
 
         try:
             spec.loader.exec_module(module)
         except FileNotFoundError as e:
             raise ValueError(f"Could not load vars file: {vars_path}") from e
+        finally:
+            sys.modules.pop(module_name, None)
 
         if not hasattr(module, "vars"):
             raise ValueError(f"Vars file {vars_path} must define a 'vars' dictionary")

--- a/tests/test_finalization_tranformations.py
+++ b/tests/test_finalization_tranformations.py
@@ -1,5 +1,6 @@
 import pytest
-from sigma.exceptions import SigmaConfigurationError, SigmaTransformationError
+import os
+from sigma.exceptions import SigmaConfigurationError, SigmaSecurityError, SigmaTransformationError
 from sigma.processing.finalization import (
     ConcatenateQueriesFinalizer,
     NestedFinalizer,
@@ -136,6 +137,7 @@ def test_template_finalizer_with_vars(dummy_pipeline):
     transformation = TemplateFinalizer(
         template='value = {{ parse_json(\'{"key": "value"}\').key }}',
         vars="tests/files/template_vars.py",
+        allow_template_vars=True,
     )
     transformation.set_pipeline(dummy_pipeline)
     assert transformation.apply(["query1", "query2"]) == "value = value"
@@ -146,6 +148,7 @@ def test_template_finalizer_with_vars_and_queries(dummy_pipeline):
     transformation = TemplateFinalizer(
         template="{% for query in queries %}{{ parse_json('{\"index\": ' ~ loop.index ~ '}').index }}{% if not loop.last %}, {% endif %}{% endfor %}",
         vars="tests/files/template_vars.py",
+        allow_template_vars=True,
     )
     transformation.set_pipeline(dummy_pipeline)
     assert transformation.apply(["query1", "query2", "query3"]) == "1, 2, 3"
@@ -156,6 +159,7 @@ def test_template_finalizer_with_json_helper(dummy_pipeline):
     transformation = TemplateFinalizer(
         template='{{ parse_json(\'{"queries": ["q1", "q2"]}\').queries | join(", ") }}',
         vars="tests/files/template_vars.py",
+        allow_template_vars=True,
     )
     transformation.set_pipeline(dummy_pipeline)
     assert transformation.apply(["query1", "query2"]) == "q1, q2"
@@ -164,7 +168,11 @@ def test_template_finalizer_with_json_helper(dummy_pipeline):
 def test_template_finalizer_with_invalid_vars_file(dummy_pipeline):
     """Test that missing 'vars' dict raises appropriate error."""
     with pytest.raises(ValueError, match="must define a 'vars' dictionary"):
-        TemplateFinalizer(template="test", vars="tests/files/invalid_template_vars.py")
+        TemplateFinalizer(
+            template="test",
+            vars="tests/files/invalid_template_vars.py",
+            allow_template_vars=True,
+        )
 
 
 def test_template_finalizer_from_dict_with_vars(dummy_pipeline):
@@ -173,6 +181,7 @@ def test_template_finalizer_from_dict_with_vars(dummy_pipeline):
         {
             "template": 'value = {{ parse_json(\'{"key": "value"}\').key }}',
             "vars": "tests/files/template_vars.py",
+            "allow_template_vars": True,
         }
     )
     transformation.set_pipeline(dummy_pipeline)
@@ -221,4 +230,82 @@ def test_json_finalizer_custom_indent(dummy_pipeline):
 def test_template_finalizer_with_nonexistent_vars_file():
     """Test that a non-existent vars file raises ValueError."""
     with pytest.raises(ValueError, match="Could not load vars file"):
-        TemplateFinalizer(template="test", vars="/nonexistent/path/vars.py")
+        TemplateFinalizer(
+            template="test", vars="/nonexistent/path/vars.py", allow_template_vars=True
+        )
+
+
+def test_template_finalizer_vars_blocked_by_default():
+    """Test that vars usage without allow_template_vars raises SigmaSecurityError."""
+    with pytest.raises(SigmaSecurityError, match="disabled by default for security reasons"):
+        TemplateFinalizer(
+            template="test",
+            vars="tests/files/template_vars.py",
+        )
+
+
+def test_template_finalizer_vars_blocked_by_default_from_dict():
+    """Test that vars usage from dict without allow_template_vars raises SigmaSecurityError."""
+    with pytest.raises(SigmaSecurityError, match="disabled by default for security reasons"):
+        TemplateFinalizer.from_dict(
+            {
+                "template": "test",
+                "vars": "tests/files/template_vars.py",
+            }
+        )
+
+
+def test_template_finalizer_vars_allowed_via_env(dummy_pipeline, monkeypatch):
+    """Test that vars usage is allowed when env var is set."""
+    monkeypatch.setenv("PYSIGMA_ALLOW_VARS_EXECUTION", "1")
+    transformation = TemplateFinalizer(
+        template='value = {{ parse_json(\'{"key": "value"}\').key }}',
+        vars="tests/files/template_vars.py",
+    )
+    transformation.set_pipeline(dummy_pipeline)
+    assert transformation.apply(["query1", "query2"]) == "value = value"
+
+
+def test_template_finalizer_no_vars_no_error(dummy_pipeline):
+    """Test that templates without vars work normally without allow_template_vars."""
+    transformation = TemplateFinalizer(template="{{ queries | join(', ') }}")
+    transformation.set_pipeline(dummy_pipeline)
+    assert transformation.apply(["q1", "q2"]) == "q1, q2"
+
+
+def test_template_finalizer_vars_allowed_path(dummy_pipeline):
+    """Test that vars file under an allowed base path is accepted."""
+    transformation = TemplateFinalizer(
+        template='value = {{ parse_json(\'{"key": "value"}\').key }}',
+        vars="tests/files/template_vars.py",
+        allow_template_vars=True,
+        vars_allowed_paths=(os.path.realpath("tests/files"),),
+    )
+    transformation.set_pipeline(dummy_pipeline)
+    assert transformation.apply(["query1"]) == "value = value"
+
+
+def test_template_finalizer_vars_blocked_by_path_allowlist(dummy_pipeline):
+    """Test that vars file outside allowed base paths raises SigmaSecurityError."""
+    with pytest.raises(SigmaSecurityError, match="outside the allowed base directories"):
+        TemplateFinalizer(
+            template="test",
+            vars="tests/files/template_vars.py",
+            allow_template_vars=True,
+            vars_allowed_paths=("/some/other/directory",),
+        )
+
+
+def test_template_finalizer_vars_allowed_paths_stripped_from_yaml(dummy_pipeline):
+    """Test that vars_allowed_paths specified in YAML is stripped."""
+    from sigma.processing.pipeline import ProcessingPipeline
+
+    with pytest.raises(SigmaSecurityError, match="disabled by default for security reasons"):
+        ProcessingPipeline.from_yaml("""
+            finalizers:
+              - type: template
+                template: "{{ queries | join(', ') }}"
+                vars: "tests/files/template_vars.py"
+                vars_allowed_paths:
+                  - "tests/files"
+            """)

--- a/tests/test_postprocessing_transformations.py
+++ b/tests/test_postprocessing_transformations.py
@@ -1,5 +1,6 @@
 import pytest
-from sigma.exceptions import SigmaConfigurationError
+import os
+from sigma.exceptions import SigmaConfigurationError, SigmaSecurityError
 from sigma.processing.pipeline import ProcessingPipeline, QueryPostprocessingItem
 from sigma.processing.postprocessing import (
     EmbedQueryInJSONTransformation,
@@ -141,6 +142,7 @@ def test_query_template_transformation_with_vars(
     transformation = QueryTemplateTransformation(
         template='value = {{ parse_json(\'{"key": "value"}\').key }}\nquery = {{ query }}',
         vars="tests/files/template_vars.py",
+        allow_template_vars=True,
     )
     transformation.set_pipeline(dummy_pipeline)
     assert (
@@ -153,7 +155,10 @@ def test_query_template_transformation_with_vars_and_path(
 ):
     """Test template transformation with custom vars from Python file and template from file."""
     transformation = QueryTemplateTransformation(
-        template="finalize.j2", path="tests/files", vars="tests/files/template_vars.py"
+        template="finalize.j2",
+        path="tests/files",
+        vars="tests/files/template_vars.py",
+        allow_template_vars=True,
     )
     transformation.set_pipeline(dummy_pipeline)
     dummy_pipeline.state["setting"] = "value"
@@ -167,7 +172,9 @@ def test_query_template_transformation_with_json_parsing(
 ):
     """Test template with JSON parsing helper function."""
     transformation = QueryTemplateTransformation(
-        template='{{ parse_json(\'{"key": "value"}\').key }}', vars="tests/files/template_vars.py"
+        template='{{ parse_json(\'{"key": "value"}\').key }}',
+        vars="tests/files/template_vars.py",
+        allow_template_vars=True,
     )
     transformation.set_pipeline(dummy_pipeline)
     assert transformation.apply(sigma_rule, 'field="value"') == "value"
@@ -178,7 +185,11 @@ def test_query_template_transformation_with_invalid_vars_file(
 ):
     """Test that missing 'vars' dict raises appropriate error."""
     with pytest.raises(ValueError, match="must define a 'vars' dictionary"):
-        QueryTemplateTransformation(template="test", vars="tests/files/invalid_template_vars.py")
+        QueryTemplateTransformation(
+            template="test",
+            vars="tests/files/invalid_template_vars.py",
+            allow_template_vars=True,
+        )
 
 
 def test_query_template_transformation_with_nonexistent_vars_file(
@@ -186,7 +197,9 @@ def test_query_template_transformation_with_nonexistent_vars_file(
 ):
     """Test that nonexistent vars file raises appropriate error."""
     with pytest.raises(ValueError, match="Could not load vars file"):
-        QueryTemplateTransformation(template="test", vars="tests/files/nonexistent.py")
+        QueryTemplateTransformation(
+            template="test", vars="tests/files/nonexistent.py", allow_template_vars=True
+        )
 
 
 def test_query_template_transformation_from_dict_with_vars(
@@ -197,9 +210,128 @@ def test_query_template_transformation_from_dict_with_vars(
         {
             "template": 'value = {{ parse_json(\'{"key": "value"}\').key }}\nquery = {{ query }}',
             "vars": "tests/files/template_vars.py",
+            "allow_template_vars": True,
         }
     )
     transformation.set_pipeline(dummy_pipeline)
     assert (
         transformation.apply(sigma_rule, 'field="value"') == 'value = value\nquery = field="value"'
     )
+
+
+def test_query_template_transformation_vars_blocked_by_default(
+    dummy_pipeline: ProcessingPipeline, sigma_rule: SigmaRule
+):
+    """Test that vars usage without allow_template_vars raises SigmaSecurityError."""
+    with pytest.raises(SigmaSecurityError, match="disabled by default for security reasons"):
+        QueryTemplateTransformation(
+            template="test",
+            vars="tests/files/template_vars.py",
+        )
+
+
+def test_query_template_transformation_vars_blocked_by_default_from_dict(
+    dummy_pipeline: ProcessingPipeline, sigma_rule: SigmaRule
+):
+    """Test that vars usage from dict without allow_template_vars raises SigmaSecurityError."""
+    with pytest.raises(SigmaSecurityError, match="disabled by default for security reasons"):
+        QueryTemplateTransformation.from_dict(
+            {
+                "template": "test",
+                "vars": "tests/files/template_vars.py",
+            }
+        )
+
+
+def test_query_template_transformation_vars_allowed_via_env(
+    dummy_pipeline: ProcessingPipeline, sigma_rule: SigmaRule, monkeypatch
+):
+    """Test that vars usage is allowed when env var is set."""
+    monkeypatch.setenv("PYSIGMA_ALLOW_VARS_EXECUTION", "1")
+    transformation = QueryTemplateTransformation(
+        template='{{ parse_json(\'{"key": "value"}\').key }}',
+        vars="tests/files/template_vars.py",
+    )
+    transformation.set_pipeline(dummy_pipeline)
+    assert transformation.apply(sigma_rule, 'field="value"') == "value"
+
+
+def test_query_template_transformation_no_vars_no_error(
+    dummy_pipeline: ProcessingPipeline, sigma_rule: SigmaRule
+):
+    """Test that templates without vars work normally without allow_template_vars."""
+    transformation = QueryTemplateTransformation(template="{{ query }}")
+    transformation.set_pipeline(dummy_pipeline)
+    assert transformation.apply(sigma_rule, 'field="value"') == 'field="value"'
+
+
+def test_query_template_transformation_vars_allowed_path(
+    dummy_pipeline: ProcessingPipeline, sigma_rule: SigmaRule
+):
+    """Test that vars file under an allowed base path is accepted."""
+    transformation = QueryTemplateTransformation(
+        template='{{ parse_json(\'{"key": "value"}\').key }}',
+        vars="tests/files/template_vars.py",
+        allow_template_vars=True,
+        vars_allowed_paths=(os.path.realpath("tests/files"),),
+    )
+    transformation.set_pipeline(dummy_pipeline)
+    assert transformation.apply(sigma_rule, 'field="value"') == "value"
+
+
+def test_query_template_transformation_vars_allowed_path_subdir(
+    dummy_pipeline: ProcessingPipeline, sigma_rule: SigmaRule
+):
+    """Test that vars file in a subdirectory of an allowed base path is accepted."""
+    transformation = QueryTemplateTransformation(
+        template='{{ parse_json(\'{"key": "value"}\').key }}',
+        vars="tests/files/template_vars.py",
+        allow_template_vars=True,
+        vars_allowed_paths=(os.path.realpath("tests"),),
+    )
+    transformation.set_pipeline(dummy_pipeline)
+    assert transformation.apply(sigma_rule, 'field="value"') == "value"
+
+
+def test_query_template_transformation_vars_blocked_by_path_allowlist(
+    dummy_pipeline: ProcessingPipeline, sigma_rule: SigmaRule
+):
+    """Test that vars file outside allowed base paths raises SigmaSecurityError."""
+    with pytest.raises(SigmaSecurityError, match="outside the allowed base directories"):
+        QueryTemplateTransformation(
+            template="test",
+            vars="tests/files/template_vars.py",
+            allow_template_vars=True,
+            vars_allowed_paths=("/some/other/directory",),
+        )
+
+
+def test_query_template_transformation_vars_no_path_restriction(
+    dummy_pipeline: ProcessingPipeline, sigma_rule: SigmaRule
+):
+    """Test that vars_allowed_paths=None imposes no path restriction."""
+    transformation = QueryTemplateTransformation(
+        template='{{ parse_json(\'{"key": "value"}\').key }}',
+        vars="tests/files/template_vars.py",
+        allow_template_vars=True,
+        vars_allowed_paths=None,
+    )
+    transformation.set_pipeline(dummy_pipeline)
+    assert transformation.apply(sigma_rule, 'field="value"') == "value"
+
+
+def test_query_template_transformation_vars_allowed_paths_from_yaml(
+    dummy_pipeline: ProcessingPipeline, sigma_rule: SigmaRule
+):
+    """Test that vars_allowed_paths specified in YAML is stripped and has no effect."""
+    with pytest.raises(SigmaSecurityError, match="disabled by default for security reasons"):
+        ProcessingPipeline.from_yaml(
+            """
+            postprocessing:
+              - type: template
+                template: "{{ query }}"
+                vars: "tests/files/template_vars.py"
+                vars_allowed_paths:
+                  - "tests/files"
+            """
+        )

--- a/tests/test_postprocessing_transformations.py
+++ b/tests/test_postprocessing_transformations.py
@@ -325,13 +325,11 @@ def test_query_template_transformation_vars_allowed_paths_from_yaml(
 ):
     """Test that vars_allowed_paths specified in YAML is stripped and has no effect."""
     with pytest.raises(SigmaSecurityError, match="disabled by default for security reasons"):
-        ProcessingPipeline.from_yaml(
-            """
+        ProcessingPipeline.from_yaml("""
             postprocessing:
               - type: template
                 template: "{{ query }}"
                 vars: "tests/files/template_vars.py"
                 vars_allowed_paths:
                   - "tests/files"
-            """
-        )
+            """)


### PR DESCRIPTION
- Introduced SigmaSecurityError for untrusted vars execution.
- Added allow_template_vars and vars_allowed_paths parameters to control vars execution.
- Updated TemplateBase to validate vars file paths against allowed directories.
- Enhanced tests to cover security scenarios for vars usage.