### PR TITLE
Harden external data source placeholder transformations

### DIFF
--- a/sigma/processing/transformations/external.py
+++ b/sigma/processing/transformations/external.py
@@ -324,9 +324,7 @@ class HTTPPlaceholderTransformation(ExternalSourceBaseTransformation):
                         )
                 encoding = response.encoding or response.apparent_encoding or "utf-8"
                 return content.decode(encoding, errors="replace")
-        except SigmaValueError:
-            raise
-        except Exception as e:
+        except requests.RequestException as e:
             raise SigmaValueError(
                 f"HTTPPlaceholderTransformation: failed to fetch '{self.url}': {e}"
             ) from e

--- a/sigma/processing/transformations/external.py
+++ b/sigma/processing/transformations/external.py
@@ -171,7 +171,7 @@ class ExternalSourceBaseTransformation(BasePlaceholderTransformation):
             result = jq.all(self.jq_expression, parsed)
         except ValueError as e:
             raise SigmaConfigurationError(f"Invalid jq expression: {e}") from e
-        return [str(v) for v in result if v is not None]
+        return self._jq_results_to_values(result)
 
     def _parse_yaml_data(self, data: str) -> list[str]:
         import jq
@@ -186,7 +186,29 @@ class ExternalSourceBaseTransformation(BasePlaceholderTransformation):
             result = jq.all(self.jq_expression, parsed)
         except ValueError as e:
             raise SigmaConfigurationError(f"Invalid jq expression: {e}") from e
-        return [str(v) for v in result if v is not None]
+        return self._jq_results_to_values(result)
+
+    @staticmethod
+    def _jq_results_to_values(result: Iterable[Any]) -> list[str]:
+        """Convert jq output into scalar placeholder values.
+
+        Each placeholder replacement becomes an individual field match value,
+        so a jq result must be a scalar. An expression that yields an array or
+        object is rejected with guidance to project to scalars (e.g. use
+        ``.items[]`` instead of ``.items``). ``None`` results are skipped.
+        """
+        values: list[str] = []
+        for v in result:
+            if v is None:
+                continue
+            if isinstance(v, (dict, list)):
+                raise SigmaConfigurationError(
+                    "jq_expression must select scalar values for placeholder "
+                    f"replacement, but a {type(v).__name__} was returned; project "
+                    "to scalars (e.g. '.items[]' instead of '.items')"
+                )
+            values.append(str(v))
+        return values
 
     def placeholder_replacements(self, p: Placeholder) -> Iterable[SigmaString]:
         return [SigmaString(v) for v in self._get_values()]

--- a/sigma/processing/transformations/external.py
+++ b/sigma/processing/transformations/external.py
@@ -19,7 +19,7 @@ import re
 import subprocess
 from abc import abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, Iterable, Union
+from typing import Any, Iterable
 
 import jq  # type: ignore[import-not-found]
 import yaml

--- a/sigma/processing/transformations/external.py
+++ b/sigma/processing/transformations/external.py
@@ -29,6 +29,9 @@ from sigma.types import Placeholder, SigmaString
 
 PYSIGMA_ALLOW_EXTERNAL_SOURCES_ENV = "PYSIGMA_ALLOW_EXTERNAL_SOURCES"
 
+# Default cap on the amount of data accepted from an external source (10 MiB).
+DEFAULT_MAX_RESPONSE_BYTES = 10 * 1024 * 1024
+
 
 @dataclass
 class ExternalSourceBaseTransformation(BasePlaceholderTransformation):
@@ -228,6 +231,8 @@ class HTTPPlaceholderTransformation(ExternalSourceBaseTransformation):
       (``application/x-www-form-urlencoded``)
     * **json_body** — optional dict to send as a JSON request body
       (``application/json``)
+    * **max_body_size** — maximum response body size in bytes; the fetch is
+      aborted with an error once this many bytes have been read (default 10 MiB)
     * **format** — data format: ``"plaintext"`` (default), ``"csv"``, ``"json"``, ``"yaml"``
     * **filter** — optional regex that each value must match (plaintext/csv)
     * **csv_column** — column name (str) or 0-based index (int) for CSV format
@@ -242,6 +247,7 @@ class HTTPPlaceholderTransformation(ExternalSourceBaseTransformation):
     params: dict[str, str] | None = None
     form_data: dict[str, Any] | None = None
     json_body: dict[str, Any] | None = None
+    max_body_size: int = DEFAULT_MAX_RESPONSE_BYTES
 
     def __post_init__(self) -> None:
         if not self.url:
@@ -254,7 +260,7 @@ class HTTPPlaceholderTransformation(ExternalSourceBaseTransformation):
         import requests
 
         try:
-            response = requests.request(
+            with requests.request(
                 method=self.method,
                 url=self.url,
                 timeout=self.timeout,
@@ -262,9 +268,21 @@ class HTTPPlaceholderTransformation(ExternalSourceBaseTransformation):
                 params=self.params,
                 data=self.form_data,
                 json=self.json_body,
-            )
-            response.raise_for_status()
-            return response.text
+                stream=True,
+            ) as response:
+                response.raise_for_status()
+                content = bytearray()
+                for chunk in response.iter_content(chunk_size=8192):
+                    content.extend(chunk)
+                    if len(content) > self.max_body_size:
+                        raise SigmaValueError(
+                            f"HTTPPlaceholderTransformation: response from '{self.url}' "
+                            f"exceeds max_body_size ({self.max_body_size} bytes)"
+                        )
+                encoding = response.encoding or response.apparent_encoding or "utf-8"
+                return content.decode(encoding, errors="replace")
+        except SigmaValueError:
+            raise
         except Exception as e:
             raise SigmaValueError(
                 f"HTTPPlaceholderTransformation: failed to fetch '{self.url}': {e}"
@@ -279,6 +297,8 @@ class CommandPlaceholderTransformation(ExternalSourceBaseTransformation):
     * **cmd** — command string (passed to ``/bin/sh -c``) or a list of
       arguments (required)
     * **timeout** — maximum execution time in seconds (default: 30)
+    * **max_stdout** — maximum accepted stdout size in bytes; output larger
+      than this is rejected with an error (default 10 MiB)
     * **format** — data format: ``"plaintext"`` (default), ``"csv"``, ``"json"``, ``"yaml"``
     * **filter** — optional regex that each value must match (plaintext/csv)
     * **csv_column** — column name (str) or 0-based index (int) for CSV format
@@ -288,6 +308,7 @@ class CommandPlaceholderTransformation(ExternalSourceBaseTransformation):
 
     cmd: str | list[str] = ""
     timeout: int = 30
+    max_stdout: int = DEFAULT_MAX_RESPONSE_BYTES
 
     def __post_init__(self) -> None:
         if not self.cmd:
@@ -318,5 +339,10 @@ class CommandPlaceholderTransformation(ExternalSourceBaseTransformation):
             raise SigmaValueError(
                 f"CommandPlaceholderTransformation: command exited with code "
                 f"{result.returncode}: {result.stderr.strip()}"
+            )
+        if len(result.stdout.encode("utf-8", errors="replace")) > self.max_stdout:
+            raise SigmaValueError(
+                f"CommandPlaceholderTransformation: command output exceeds "
+                f"max_stdout ({self.max_stdout} bytes)"
             )
         return result.stdout

--- a/sigma/processing/transformations/external.py
+++ b/sigma/processing/transformations/external.py
@@ -43,8 +43,9 @@ class ExternalSourceBaseTransformation(BasePlaceholderTransformation):
     * ``"plaintext"`` — one value per line; an optional *filter* regex must
       match for a line to be included.
     * ``"csv"`` — CSV data; *csv_column* selects the column (column header
-      name **or** 0-based integer index); an optional *filter* regex is
-      applied to each extracted cell value.
+      name **or** 0-based integer index); *csv_has_header* (default ``True``)
+      controls whether the first row is treated as a header; an optional
+      *filter* regex is applied to each extracted cell value.
     * ``"json"`` — JSON data; *jq_expression* selects the value(s).
     * ``"yaml"`` — YAML data; *jq_expression* selects the value(s).
 
@@ -57,6 +58,7 @@ class ExternalSourceBaseTransformation(BasePlaceholderTransformation):
     format: str = "plaintext"
     filter: str | None = None
     csv_column: str | int | None = None
+    csv_has_header: bool = True
     jq_expression: str | None = None
     allow_external_sources: bool = False
 
@@ -129,6 +131,10 @@ class ExternalSourceBaseTransformation(BasePlaceholderTransformation):
         values: list[str] = []
 
         if isinstance(self.csv_column, str):
+            if not self.csv_has_header:
+                raise SigmaConfigurationError(
+                    "CSV column referenced by name requires a header row (csv_has_header=True)"
+                )
             reader_dict = csv.DictReader(io.StringIO(data))
             for row in reader_dict:
                 if self.csv_column not in row:
@@ -140,8 +146,10 @@ class ExternalSourceBaseTransformation(BasePlaceholderTransformation):
                     values.append(val)
         else:
             col_idx = self.csv_column
-            reader_list = csv.reader(io.StringIO(data))
-            for csv_row in reader_list:
+            rows = iter(csv.reader(io.StringIO(data)))
+            if self.csv_has_header:
+                next(rows, None)  # discard header row for consistency with name-based mode
+            for csv_row in rows:
                 if col_idx < len(csv_row):
                     values.append(csv_row[col_idx])
 
@@ -193,6 +201,7 @@ class FilePlaceholderTransformation(ExternalSourceBaseTransformation):
     * **format** — data format: ``"plaintext"`` (default), ``"csv"``, ``"json"``, ``"yaml"``
     * **filter** — optional regex that each value must match (plaintext/csv)
     * **csv_column** — column name (str) or 0-based index (int) for CSV format
+    * **csv_has_header** — whether the first CSV row is a header (default ``True``)
     * **jq_expression** — path expression for JSON/YAML formats (e.g. ``.items[]``)
     * **include** / **exclude** — placeholder name lists (from
       :class:`~sigma.processing.transformations.placeholder.BasePlaceholderTransformation`)
@@ -236,6 +245,7 @@ class HTTPPlaceholderTransformation(ExternalSourceBaseTransformation):
     * **format** — data format: ``"plaintext"`` (default), ``"csv"``, ``"json"``, ``"yaml"``
     * **filter** — optional regex that each value must match (plaintext/csv)
     * **csv_column** — column name (str) or 0-based index (int) for CSV format
+    * **csv_has_header** — whether the first CSV row is a header (default ``True``)
     * **jq_expression** — path expression for JSON/YAML formats
     * **include** / **exclude** — placeholder name lists
     """
@@ -302,6 +312,7 @@ class CommandPlaceholderTransformation(ExternalSourceBaseTransformation):
     * **format** — data format: ``"plaintext"`` (default), ``"csv"``, ``"json"``, ``"yaml"``
     * **filter** — optional regex that each value must match (plaintext/csv)
     * **csv_column** — column name (str) or 0-based index (int) for CSV format
+    * **csv_has_header** — whether the first CSV row is a header (default ``True``)
     * **jq_expression** — path expression for JSON/YAML formats
     * **include** / **exclude** — placeholder name lists
     """

--- a/sigma/processing/transformations/external.py
+++ b/sigma/processing/transformations/external.py
@@ -21,7 +21,6 @@ from abc import abstractmethod
 from dataclasses import dataclass, field
 from typing import Any, Iterable
 
-import jq  # type: ignore[import-not-found]
 import yaml
 
 from sigma.exceptions import SigmaConfigurationError, SigmaSecurityError, SigmaValueError
@@ -149,6 +148,8 @@ class ExternalSourceBaseTransformation(BasePlaceholderTransformation):
         return values
 
     def _parse_json(self, data: str) -> list[str]:
+        import jq  # type: ignore[import-not-found]
+
         if self.jq_expression is None:
             raise SigmaConfigurationError("'jq_expression' must be specified when format is 'json'")
         try:
@@ -162,6 +163,8 @@ class ExternalSourceBaseTransformation(BasePlaceholderTransformation):
         return [str(v) for v in result if v is not None]
 
     def _parse_yaml_data(self, data: str) -> list[str]:
+        import jq
+
         if self.jq_expression is None:
             raise SigmaConfigurationError("'jq_expression' must be specified when format is 'yaml'")
         try:

--- a/sigma/processing/transformations/external.py
+++ b/sigma/processing/transformations/external.py
@@ -32,6 +32,9 @@ PYSIGMA_ALLOW_EXTERNAL_SOURCES_ENV = "PYSIGMA_ALLOW_EXTERNAL_SOURCES"
 # Default cap on the amount of data accepted from an external source (10 MiB).
 DEFAULT_MAX_RESPONSE_BYTES = 10 * 1024 * 1024
 
+# Data formats understood by the external source parsers.
+SUPPORTED_FORMATS = ("plaintext", "csv", "json", "yaml")
+
 
 @dataclass
 class ExternalSourceBaseTransformation(BasePlaceholderTransformation):
@@ -63,6 +66,14 @@ class ExternalSourceBaseTransformation(BasePlaceholderTransformation):
     allow_external_sources: bool = False
 
     _values_cache: list[str] | None = field(init=False, default=None, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        if self.format not in SUPPORTED_FORMATS:
+            raise SigmaConfigurationError(
+                f"Unknown external source format '{self.format}'. "
+                f"Supported formats: {', '.join(SUPPORTED_FORMATS)}."
+            )
+        super().__post_init__()
 
     def _external_sources_allowed(self) -> bool:
         """Return *True* if external data sources are permitted."""
@@ -114,7 +125,7 @@ class ExternalSourceBaseTransformation(BasePlaceholderTransformation):
         else:
             raise SigmaConfigurationError(
                 f"Unknown external source format '{self.format}'. "
-                "Supported formats: plaintext, csv, json, yaml."
+                f"Supported formats: {', '.join(SUPPORTED_FORMATS)}."
             )
 
     def _parse_plaintext(self, data: str) -> list[str]:
@@ -236,7 +247,7 @@ class FilePlaceholderTransformation(ExternalSourceBaseTransformation):
             raise SigmaConfigurationError(
                 "FilePlaceholderTransformation requires a non-empty 'path'"
             )
-        BasePlaceholderTransformation.__post_init__(self)
+        super().__post_init__()
 
     def _fetch_data(self) -> str:
         try:
@@ -286,7 +297,7 @@ class HTTPPlaceholderTransformation(ExternalSourceBaseTransformation):
             raise SigmaConfigurationError(
                 "HTTPPlaceholderTransformation requires a non-empty 'url'"
             )
-        BasePlaceholderTransformation.__post_init__(self)
+        super().__post_init__()
 
     def _fetch_data(self) -> str:
         import requests
@@ -348,7 +359,7 @@ class CommandPlaceholderTransformation(ExternalSourceBaseTransformation):
             raise SigmaConfigurationError(
                 "CommandPlaceholderTransformation requires a non-empty 'cmd'"
             )
-        BasePlaceholderTransformation.__post_init__(self)
+        super().__post_init__()
 
     def _fetch_data(self) -> str:
         try:

--- a/tests/test_external_placeholder_transformations.py
+++ b/tests/test_external_placeholder_transformations.py
@@ -216,11 +216,10 @@ class TestExternalValueSourceParsers:
             t._parse_data("key: val")
 
     def test_unknown_format_raises(self):
-        t = FilePlaceholderTransformation(
-            path=PLAINTEXT_FILE, allow_external_sources=True, format="xml"
-        )
         with pytest.raises(SigmaConfigurationError, match="Unknown external source format"):
-            t._parse_data("<root/>")
+            FilePlaceholderTransformation(
+                path=PLAINTEXT_FILE, allow_external_sources=True, format="xml"
+            )
 
 
 class TestSecurityFlag:

--- a/tests/test_external_placeholder_transformations.py
+++ b/tests/test_external_placeholder_transformations.py
@@ -30,6 +30,19 @@ JSON_FILE = str(FILES_DIR / "placeholder_values.json")
 YAML_FILE = str(FILES_DIR / "placeholder_values.yaml")
 
 
+def _streaming_response(body: bytes, *, chunk_size: int = 8192) -> MagicMock:
+    """Build a mock ``requests`` response usable as a streaming context manager."""
+    resp = MagicMock()
+    resp.__enter__.return_value = resp
+    resp.__exit__.return_value = False
+    resp.encoding = "utf-8"
+    resp.raise_for_status = MagicMock()
+    resp.iter_content.return_value = [
+        body[i : i + chunk_size] for i in range(0, len(body), chunk_size)
+    ]
+    return resp
+
+
 @pytest.fixture
 def dummy_pipeline():
     return ProcessingPipeline([], {})
@@ -358,10 +371,7 @@ class TestHTTPPlaceholderTransformation:
 
     def test_http_post_with_json_body(self, dummy_pipeline):
         with patch("requests.request") as mock_req:
-            mock_resp = MagicMock()
-            mock_resp.text = "result1\nresult2\n"
-            mock_resp.raise_for_status = MagicMock()
-            mock_req.return_value = mock_resp
+            mock_req.return_value = _streaming_response(b"result1\nresult2\n")
 
             t = HTTPPlaceholderTransformation(
                 url="http://example.com/api",
@@ -380,14 +390,12 @@ class TestHTTPPlaceholderTransformation:
                 params=None,
                 data=None,
                 json={"query": "all"},
+                stream=True,
             )
 
     def test_http_post_with_form_data(self, dummy_pipeline):
         with patch("requests.request") as mock_req:
-            mock_resp = MagicMock()
-            mock_resp.text = "a\nb\n"
-            mock_resp.raise_for_status = MagicMock()
-            mock_req.return_value = mock_resp
+            mock_req.return_value = _streaming_response(b"a\nb\n")
 
             t = HTTPPlaceholderTransformation(
                 url="http://example.com/form",
@@ -405,14 +413,12 @@ class TestHTTPPlaceholderTransformation:
                 params=None,
                 data={"token": "secret"},
                 json=None,
+                stream=True,
             )
 
     def test_http_custom_headers(self, dummy_pipeline):
         with patch("requests.request") as mock_req:
-            mock_resp = MagicMock()
-            mock_resp.text = "v1\n"
-            mock_resp.raise_for_status = MagicMock()
-            mock_req.return_value = mock_resp
+            mock_req.return_value = _streaming_response(b"v1\n")
 
             t = HTTPPlaceholderTransformation(
                 url="http://example.com/",
@@ -429,14 +435,12 @@ class TestHTTPPlaceholderTransformation:
                 params=None,
                 data=None,
                 json=None,
+                stream=True,
             )
 
     def test_http_query_params(self, dummy_pipeline):
         with patch("requests.request") as mock_req:
-            mock_resp = MagicMock()
-            mock_resp.text = "v1\n"
-            mock_resp.raise_for_status = MagicMock()
-            mock_req.return_value = mock_resp
+            mock_req.return_value = _streaming_response(b"v1\n")
 
             t = HTTPPlaceholderTransformation(
                 url="http://example.com/search",
@@ -453,7 +457,21 @@ class TestHTTPPlaceholderTransformation:
                 params={"type": "ip", "limit": "100"},
                 data=None,
                 json=None,
+                stream=True,
             )
+
+    def test_http_max_body_size_exceeded(self, dummy_pipeline):
+        with patch("requests.request") as mock_req:
+            mock_req.return_value = _streaming_response(b"x" * 5000, chunk_size=1000)
+
+            t = HTTPPlaceholderTransformation(
+                url="http://example.com/big",
+                allow_external_sources=True,
+                max_body_size=2000,
+            )
+            t.set_pipeline(dummy_pipeline)
+            with pytest.raises(SigmaValueError, match="exceeds max_body_size"):
+                t._get_values()
 
 
 class TestCommandPlaceholderTransformation:
@@ -516,6 +534,16 @@ class TestCommandPlaceholderTransformation:
             )
             t.set_pipeline(dummy_pipeline)
             assert t._get_values() == ["x", "y"]
+
+    def test_max_stdout_exceeded(self, dummy_pipeline):
+        t = CommandPlaceholderTransformation(
+            cmd=["printf", "%s", "x" * 5000],
+            allow_external_sources=True,
+            max_stdout=1000,
+        )
+        t.set_pipeline(dummy_pipeline)
+        with pytest.raises(SigmaValueError, match="exceeds max_stdout"):
+            t._get_values()
 
 
 class TestPipelineIntegration:

--- a/tests/test_external_placeholder_transformations.py
+++ b/tests/test_external_placeholder_transformations.py
@@ -159,6 +159,28 @@ class TestExternalValueSourceParsers:
         )
         assert t._parse_data(data) == ["a", "b", "c"]
 
+    def test_json_array_value_raises(self):
+        data = json.dumps({"items": ["a", "b"]})
+        t = FilePlaceholderTransformation(
+            path=PLAINTEXT_FILE,
+            allow_external_sources=True,
+            format="json",
+            jq_expression=".items",
+        )
+        with pytest.raises(SigmaConfigurationError, match="must select scalar values"):
+            t._parse_data(data)
+
+    def test_json_object_value_raises(self):
+        data = json.dumps({"items": [{"a": 1}, {"a": 2}]})
+        t = FilePlaceholderTransformation(
+            path=PLAINTEXT_FILE,
+            allow_external_sources=True,
+            format="json",
+            jq_expression=".items[]",
+        )
+        with pytest.raises(SigmaConfigurationError, match="must select scalar values"):
+            t._parse_data(data)
+
     def test_json_no_expression_raises(self):
         t = FilePlaceholderTransformation(
             path=PLAINTEXT_FILE, allow_external_sources=True, format="json"

--- a/tests/test_external_placeholder_transformations.py
+++ b/tests/test_external_placeholder_transformations.py
@@ -93,7 +93,31 @@ class TestExternalValueSourceParsers:
         t = FilePlaceholderTransformation(
             path=PLAINTEXT_FILE, allow_external_sources=True, format="csv", csv_column=1
         )
-        assert t._parse_data(data) == ["score", "10", "20"]
+        # Header row is skipped by default, consistent with column-name mode.
+        assert t._parse_data(data) == ["10", "20"]
+
+    def test_csv_by_column_index_no_header(self):
+        data = "alice,10\nbob,20\n"
+        t = FilePlaceholderTransformation(
+            path=PLAINTEXT_FILE,
+            allow_external_sources=True,
+            format="csv",
+            csv_column=1,
+            csv_has_header=False,
+        )
+        assert t._parse_data(data) == ["10", "20"]
+
+    def test_csv_by_column_name_without_header_raises(self):
+        data = "alice,10\nbob,20\n"
+        t = FilePlaceholderTransformation(
+            path=PLAINTEXT_FILE,
+            allow_external_sources=True,
+            format="csv",
+            csv_column="score",
+            csv_has_header=False,
+        )
+        with pytest.raises(SigmaConfigurationError, match="requires a header row"):
+            t._parse_data(data)
 
     def test_csv_missing_column_raises(self):
         data = "name,score\nalice,10\n"


### PR DESCRIPTION
Follow-up to #471 (and #470) with seven small, independent commits hardening the new external source placeholder transformations.

## Changes

- Lazy-import `jq` so importing pySigma no longer requires the compiled jq extension. It loads only when a json/yaml source is evaluated, matching the existing lazy `requests` import.
- Bound response sizes so a hostile or oversized source cannot exhaust memory: HTTP streams the body with a `max_body_size` cap, and command output is rejected past `max_stdout`. Both default to 10 MiB and are configurable per source.
- Make CSV column handling consistent. Name mode used `DictReader` (skips the header) while index mode used `csv.reader` (did not), so the header cell leaked through. Add `csv_has_header` (default true): index mode now skips the header like name mode, and name mode errors clearly when there is no header.
- Reject non-scalar `jq` results instead of stringifying them into a Python repr. A placeholder replacement becomes a single field match value, so an array or object is a user error. The message points at scalar projection (use `.items[]` not `.items`).
- Validate `format` at construction time instead of only at apply time.
- Narrow the HTTP fetch to catch `requests.RequestException` rather than bare `Exception`, so the size cap error and genuine bugs propagate unwrapped.
- Remove an unused import.

## Test plan

- `poetry run pytest tests/test_external_placeholder_transformations.py`
- `poetry run pytest` (full suite: 1464 passed, 1 skipped)
- `poetry run black --check .`
- `poetry run mypy`