### PR TITLE
fix: strip wildcards and add field filtering to HashesFieldsDetectionItemTransformation

### DIFF
--- a/sigma/processing/transformations/values.py
+++ b/sigma/processing/transformations/values.py
@@ -48,6 +48,7 @@ class HashesFieldsDetectionItemTransformation(DetectionItemTransformation):
         valid_hash_algos (list[str]): List of supported hash algorithms.
         field_prefix (str): Prefix to add to the new field names.
         drop_algo_prefix (bool): If True, omits the algorithm name from the new field name.
+        field_toparse (list[str]): List of field names to parse for hash values. Defaults to ["Hashes", "Hash"].
         hash_lengths (dict[int, str]): Mapping of hash lengths to their corresponding algorithms.
 
     Example:
@@ -63,6 +64,7 @@ class HashesFieldsDetectionItemTransformation(DetectionItemTransformation):
     valid_hash_algos: list[str]
     field_prefix: str = ""
     drop_algo_prefix: bool = False
+    field_toparse: list[str] = field(default_factory=lambda: ["Hashes", "Hash"])
     hash_lengths: ClassVar[dict[int, str]] = {32: "MD5", 40: "SHA1", 64: "SHA256", 128: "SHA512"}
 
     def apply_detection_item(
@@ -81,6 +83,8 @@ class HashesFieldsDetectionItemTransformation(DetectionItemTransformation):
         Raises:
             Exception: If no valid hash algorithms were found in the detection item.
         """
+        if detection_item.field not in self.field_toparse:
+            return None
         if (
             isinstance(detection_item.value, SigmaString)
             or isinstance(detection_item.value, list)

--- a/sigma/processing/transformations/values.py
+++ b/sigma/processing/transformations/values.py
@@ -48,7 +48,7 @@ class HashesFieldsDetectionItemTransformation(DetectionItemTransformation):
         valid_hash_algos (list[str]): List of supported hash algorithms.
         field_prefix (str): Prefix to add to the new field names.
         drop_algo_prefix (bool): If True, omits the algorithm name from the new field name.
-        field_toparse (list[str]): List of field names to parse for hash values. Defaults to ["Hashes", "Hash"].
+        field_to_parse (list[str]): List of field names to parse for hash values. Defaults to ["Hashes", "Hash"].
         hash_lengths (dict[int, str]): Mapping of hash lengths to their corresponding algorithms.
 
     Example:
@@ -64,7 +64,7 @@ class HashesFieldsDetectionItemTransformation(DetectionItemTransformation):
     valid_hash_algos: list[str]
     field_prefix: str = ""
     drop_algo_prefix: bool = False
-    field_toparse: list[str] = field(default_factory=lambda: ["Hashes", "Hash"])
+    field_to_parse: list[str] = field(default_factory=lambda: ["Hashes", "Hash"])
     hash_lengths: ClassVar[dict[int, str]] = {32: "MD5", 40: "SHA1", 64: "SHA256", 128: "SHA512"}
 
     def apply_detection_item(
@@ -83,7 +83,7 @@ class HashesFieldsDetectionItemTransformation(DetectionItemTransformation):
         Raises:
             Exception: If no valid hash algorithms were found in the detection item.
         """
-        if detection_item.field not in self.field_toparse:
+        if detection_item.field not in self.field_to_parse:
             return None
         if (
             isinstance(detection_item.value, SigmaString)

--- a/sigma/processing/transformations/values.py
+++ b/sigma/processing/transformations/values.py
@@ -134,8 +134,9 @@ class HashesFieldsDetectionItemTransformation(DetectionItemTransformation):
         if len(parts) == 2:
             hash_algo, hash_value = parts
             hash_algo = hash_algo.lstrip("*").upper()
+            hash_value = hash_value.strip("*?")
         else:
-            hash_value = parts[0]
+            hash_value = parts[0].strip("*?")
             hash_algo = self._determine_hash_algo_by_length(hash_value)
 
         return (hash_algo, hash_value) if hash_algo in self.valid_hash_algos else ("", hash_value)

--- a/tests/test_processing_transformations.py
+++ b/tests/test_processing_transformations.py
@@ -2616,6 +2616,32 @@ def test_hashes_transformation_no_string_value(hashes_transformation):
     assert hashes_transformation.apply_detection_item(detection_item) is None
 
 
+def test_hashes_transformation_wildcard_wrapped_explicit(hashes_transformation):
+    detection_item = SigmaDetectionItem(
+        "Hashes", [], [SigmaString("*SHA1=5F1CBC3D99558307BC1250D084FA968521482025*")]
+    )
+    result = hashes_transformation.apply_detection_item(detection_item)
+    assert isinstance(result, SigmaDetection)
+    assert len(result.detection_items) == 1
+    assert result.detection_items[0].field == "FileSHA1"
+    assert result.detection_items[0].value == [
+        SigmaString("5F1CBC3D99558307BC1250D084FA968521482025")
+    ]
+
+
+def test_hashes_transformation_wildcard_wrapped_auto_detect(hashes_transformation):
+    detection_item = SigmaDetectionItem(
+        "Hashes", [], [SigmaString("*5F1CBC3D99558307BC1250D084FA968521482025*")]
+    )
+    result = hashes_transformation.apply_detection_item(detection_item)
+    assert isinstance(result, SigmaDetection)
+    assert len(result.detection_items) == 1
+    assert result.detection_items[0].field == "FileSHA1"
+    assert result.detection_items[0].value == [
+        SigmaString("5F1CBC3D99558307BC1250D084FA968521482025")
+    ]
+
+
 def test_case_transformation_lower(dummy_pipeline):
     detection_item = SigmaDetectionItem("field", [], [SigmaString("AbC")])
     transformation = CaseTransformation(method="lower")

--- a/tests/test_processing_transformations.py
+++ b/tests/test_processing_transformations.py
@@ -2642,6 +2642,58 @@ def test_hashes_transformation_wildcard_wrapped_auto_detect(hashes_transformatio
     ]
 
 
+def test_hashes_transformation_field_hash(hashes_transformation):
+    detection_item = SigmaDetectionItem(
+        "Hash", [], [SigmaString("SHA1=5F1CBC3D99558307BC1250D084FA968521482025")]
+    )
+    result = hashes_transformation.apply_detection_item(detection_item)
+    assert isinstance(result, SigmaDetection)
+    assert len(result.detection_items) == 1
+    assert result.detection_items[0].field == "FileSHA1"
+    assert result.detection_items[0].value == [
+        SigmaString("5F1CBC3D99558307BC1250D084FA968521482025")
+    ]
+
+
+def test_hashes_transformation_wrong_field(hashes_transformation):
+    detection_item = SigmaDetectionItem(
+        "FileName", [], [SigmaString("SHA1=5F1CBC3D99558307BC1250D084FA968521482025")]
+    )
+    assert hashes_transformation.apply_detection_item(detection_item) is None
+
+
+def test_hashes_transformation_custom_field():
+    transformation = HashesFieldsDetectionItemTransformation(
+        valid_hash_algos=["MD5", "SHA1", "SHA256", "SHA512"],
+        field_prefix="File",
+        drop_algo_prefix=False,
+        field_toparse=["FileHash"],
+    )
+    detection_item = SigmaDetectionItem(
+        "FileHash", [], [SigmaString("SHA1=5F1CBC3D99558307BC1250D084FA968521482025")]
+    )
+    result = transformation.apply_detection_item(detection_item)
+    assert isinstance(result, SigmaDetection)
+    assert len(result.detection_items) == 1
+    assert result.detection_items[0].field == "FileSHA1"
+    assert result.detection_items[0].value == [
+        SigmaString("5F1CBC3D99558307BC1250D084FA968521482025")
+    ]
+
+
+def test_hashes_transformation_custom_field_ignored(hashes_transformation):
+    transformation = HashesFieldsDetectionItemTransformation(
+        valid_hash_algos=["MD5", "SHA1", "SHA256", "SHA512"],
+        field_prefix="File",
+        drop_algo_prefix=False,
+        field_toparse=["FileHash"],
+    )
+    detection_item = SigmaDetectionItem(
+        "Hashes", [], [SigmaString("SHA1=5F1CBC3D99558307BC1250D084FA968521482025")]
+    )
+    assert transformation.apply_detection_item(detection_item) is None
+
+
 def test_case_transformation_lower(dummy_pipeline):
     detection_item = SigmaDetectionItem("field", [], [SigmaString("AbC")])
     transformation = CaseTransformation(method="lower")

--- a/tests/test_processing_transformations.py
+++ b/tests/test_processing_transformations.py
@@ -2667,7 +2667,7 @@ def test_hashes_transformation_custom_field():
         valid_hash_algos=["MD5", "SHA1", "SHA256", "SHA512"],
         field_prefix="File",
         drop_algo_prefix=False,
-        field_toparse=["FileHash"],
+        field_to_parse=["FileHash"],
     )
     detection_item = SigmaDetectionItem(
         "FileHash", [], [SigmaString("SHA1=5F1CBC3D99558307BC1250D084FA968521482025")]
@@ -2686,7 +2686,7 @@ def test_hashes_transformation_custom_field_ignored(hashes_transformation):
         valid_hash_algos=["MD5", "SHA1", "SHA256", "SHA512"],
         field_prefix="File",
         drop_algo_prefix=False,
-        field_toparse=["FileHash"],
+        field_to_parse=["FileHash"],
     )
     detection_item = SigmaDetectionItem(
         "Hashes", [], [SigmaString("SHA1=5F1CBC3D99558307BC1250D084FA968521482025")]

--- a/tests/test_processing_transformations.py
+++ b/tests/test_processing_transformations.py
@@ -2700,7 +2700,9 @@ def test_hashes_transformation_none_field():
         field_prefix="File",
         drop_algo_prefix=False,
     )
-    detection_item = SigmaDetectionItem(None, [], [SigmaString("SHA1=5F1CBC3D99558307BC1250D084FA968521482025")])
+    detection_item = SigmaDetectionItem(
+        None, [], [SigmaString("SHA1=5F1CBC3D99558307BC1250D084FA968521482025")]
+    )
     assert transformation.apply_detection_item(detection_item) is None
 
 

--- a/tests/test_processing_transformations.py
+++ b/tests/test_processing_transformations.py
@@ -2694,6 +2694,86 @@ def test_hashes_transformation_custom_field_ignored(hashes_transformation):
     assert transformation.apply_detection_item(detection_item) is None
 
 
+def test_hashes_transformation_none_field():
+    transformation = HashesFieldsDetectionItemTransformation(
+        valid_hash_algos=["MD5", "SHA1", "SHA256", "SHA512"],
+        field_prefix="File",
+        drop_algo_prefix=False,
+    )
+    detection_item = SigmaDetectionItem(None, [], [SigmaString("SHA1=5F1CBC3D99558307BC1250D084FA968521482025")])
+    assert transformation.apply_detection_item(detection_item) is None
+
+
+def test_hashes_transformation_multiple_same_type():
+    transformation = HashesFieldsDetectionItemTransformation(
+        valid_hash_algos=["MD5", "SHA1", "SHA256", "SHA512"],
+        field_prefix="File",
+        drop_algo_prefix=False,
+    )
+    detection_item = SigmaDetectionItem(
+        "Hashes",
+        [],
+        [
+            SigmaString("MD5=987B65CD9B9F4E9A1AFD8F8B48CF64A7"),
+            SigmaString("MD5=A87B65CD9B9F4E9A1AFD8F8B48CF64A8"),
+        ],
+    )
+    result = transformation.apply_detection_item(detection_item)
+    assert isinstance(result, SigmaDetection)
+    assert len(result.detection_items) == 1
+    assert result.detection_items[0].field == "FileMD5"
+    assert len(result.detection_items[0].value) == 2
+    assert result.detection_items[0].value[0] == SigmaString("987B65CD9B9F4E9A1AFD8F8B48CF64A7")
+    assert result.detection_items[0].value[1] == SigmaString("A87B65CD9B9F4E9A1AFD8F8B48CF64A8")
+
+
+def test_hashes_transformation_empty_field_toparse():
+    transformation = HashesFieldsDetectionItemTransformation(
+        valid_hash_algos=["MD5", "SHA1", "SHA256", "SHA512"],
+        field_prefix="File",
+        drop_algo_prefix=False,
+        field_to_parse=[],
+    )
+    detection_item = SigmaDetectionItem(
+        "Hashes", [], [SigmaString("SHA1=5F1CBC3D99558307BC1250D084FA968521482025")]
+    )
+    assert transformation.apply_detection_item(detection_item) is None
+
+
+def test_hashes_transformation_single_field_toparse():
+    transformation = HashesFieldsDetectionItemTransformation(
+        valid_hash_algos=["MD5", "SHA1", "SHA256", "SHA512"],
+        field_prefix="File",
+        drop_algo_prefix=False,
+        field_to_parse=["Hash"],
+    )
+    detection_item = SigmaDetectionItem(
+        "Hash", [], [SigmaString("SHA1=5F1CBC3D99558307BC1250D084FA968521482025")]
+    )
+    result = transformation.apply_detection_item(detection_item)
+    assert isinstance(result, SigmaDetection)
+    assert len(result.detection_items) == 1
+    assert result.detection_items[0].field == "FileSHA1"
+
+
+def test_hashes_transformation_star_prefix_algo():
+    transformation = HashesFieldsDetectionItemTransformation(
+        valid_hash_algos=["MD5", "SHA1", "SHA256", "SHA512"],
+        field_prefix="File",
+        drop_algo_prefix=False,
+    )
+    detection_item = SigmaDetectionItem(
+        "Hashes", [], [SigmaString("*SHA1=5F1CBC3D99558307BC1250D084FA968521482025")]
+    )
+    result = transformation.apply_detection_item(detection_item)
+    assert isinstance(result, SigmaDetection)
+    assert len(result.detection_items) == 1
+    assert result.detection_items[0].field == "FileSHA1"
+    assert result.detection_items[0].value == [
+        SigmaString("5F1CBC3D99558307BC1250D084FA968521482025")
+    ]
+
+
 def test_case_transformation_lower(dummy_pipeline):
     detection_item = SigmaDetectionItem("field", [], [SigmaString("AbC")])
     transformation = CaseTransformation(method="lower")


### PR DESCRIPTION
## Summary

Fixes two bugs in `HashesFieldsDetectionItemTransformation` :

1. **Wildcard stripping** — Hash values were emitted with trailing wildcards (e.g., `IMPHASH IN ("BCCA3C...*"))` when using `Hashes|contains:` ([#487](https://github.com/SigmaHQ/pySigma/pull/487))
2. **Field filtering** — The transformation was applied to ALL detection items, not only those with field "Hashes"/"Hash"

## Changes

- Added `field_to_parse` attribute (default: `["Hashes", "Hash"]`) to restrict transformation
- Strip wildcards `*?` from hash values in both extraction branches
- 19 tests covering all edge cases

## Verification

- [x] `black --check` passed
- [x] `pytest` — 19/19 tests passed

Closes #486, #487