### PR TITLE
feat: add GenericTypeValueTransformation for regex-based field extraction

### DIFF
--- a/sigma/processing/transformations/__init__.py
+++ b/sigma/processing/transformations/__init__.py
@@ -36,6 +36,7 @@ from sigma.processing.transformations.rule import (
 from sigma.processing.transformations.state import SetStateTransformation
 from sigma.processing.transformations.values import (
     ConvertTypeTransformation,
+    GenericTypeValueTransformation,
     HashesFieldsDetectionItemTransformation,
     MapStringTransformation,
     RegexTransformation,
@@ -50,6 +51,7 @@ transformations: dict[str, Type[Transformation]] = {
     "field_name_transform": FieldFunctionTransformation,
     "drop_detection_item": DropDetectionItemTransformation,
     "hashes_fields": HashesFieldsDetectionItemTransformation,
+    "generic_type_value": GenericTypeValueTransformation,
     "field_name_suffix": AddFieldnameSuffixTransformation,
     "field_name_prefix": AddFieldnamePrefixTransformation,
     "wildcard_placeholders": WildcardPlaceholderTransformation,
@@ -85,6 +87,7 @@ __all__ = [
     "FieldFunctionTransformation",
     "DropDetectionItemTransformation",
     "HashesFieldsDetectionItemTransformation",
+    "GenericTypeValueTransformation",
     "AddFieldnameSuffixTransformation",
     "AddFieldnamePrefixTransformation",
     "WildcardPlaceholderTransformation",

--- a/sigma/processing/transformations/__init__.py
+++ b/sigma/processing/transformations/__init__.py
@@ -36,7 +36,7 @@ from sigma.processing.transformations.rule import (
 from sigma.processing.transformations.state import SetStateTransformation
 from sigma.processing.transformations.values import (
     ConvertTypeTransformation,
-    GenericTypeValueTransformation,
+    ExtractFieldsTransformation,
     HashesFieldsDetectionItemTransformation,
     MapStringTransformation,
     RegexTransformation,
@@ -51,7 +51,7 @@ transformations: dict[str, Type[Transformation]] = {
     "field_name_transform": FieldFunctionTransformation,
     "drop_detection_item": DropDetectionItemTransformation,
     "hashes_fields": HashesFieldsDetectionItemTransformation,
-    "generic_type_value": GenericTypeValueTransformation,
+    "extract_fields": ExtractFieldsTransformation,
     "field_name_suffix": AddFieldnameSuffixTransformation,
     "field_name_prefix": AddFieldnamePrefixTransformation,
     "wildcard_placeholders": WildcardPlaceholderTransformation,
@@ -87,7 +87,7 @@ __all__ = [
     "FieldFunctionTransformation",
     "DropDetectionItemTransformation",
     "HashesFieldsDetectionItemTransformation",
-    "GenericTypeValueTransformation",
+    "ExtractFieldsTransformation",
     "AddFieldnameSuffixTransformation",
     "AddFieldnamePrefixTransformation",
     "WildcardPlaceholderTransformation",

--- a/sigma/processing/transformations/values.py
+++ b/sigma/processing/transformations/values.py
@@ -475,10 +475,12 @@ class GenericTypeValueTransformation(DetectionItemTransformation):
         regex (str): Regex pattern with named groups (e.g., (?P<name>pattern)).
             Default: r"(?P<type>[?A-Za-z0-9_]+):(?P<value>[^\\s=|]+)"
         field_prefix (str): Prefix for field names. Used as {field_prefix}.{group_name}.
+        field_to_parse (list[str] | None): List of field names to parse. If None, all fields are parsed.
     """
 
     regex: str = r"(?P<type>[A-Za-z0-9_]+):(?P<value>[^\s=|]+)"
     field_prefix: str = ""
+    field_to_parse: list[str] | None = None
 
     def __post_init__(self) -> None:
         if hasattr(super(), "__post_init__"):
@@ -551,6 +553,10 @@ class GenericTypeValueTransformation(DetectionItemTransformation):
                 or None if no values match the pattern.
         """
         if not self.field_prefix:
+            return None
+
+        # Filter by field_to_parse if specified
+        if self.field_to_parse is not None and detection_item.field not in self.field_to_parse:
             return None
 
         if not isinstance(detection_item.value, list) or not all(

--- a/sigma/processing/transformations/values.py
+++ b/sigma/processing/transformations/values.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from sigma.conditions import ConditionOR
+from sigma.conditions import ConditionAND, ConditionOR
 from typing import (
     ClassVar,
     Literal,
@@ -443,3 +443,127 @@ class CaseTransformation(StringValueTransformation):
             return val.lower()
         else:
             return val.upper()
+
+
+@dataclass
+class GenericTypeValueTransformation(DetectionItemTransformation):
+    """
+    Transforms values matching a regex pattern with named groups into separate detection items.
+
+    Extracts named capture groups from a regex match and creates one detection item per group.
+    Each item uses the field prefix followed by the group name:
+    - {field_prefix}.{group_name}: captured value
+
+    Example:
+        regex = r"(?P<type>Dword):(?P<valeur>[0-9]+)"
+        field_prefix = "reg"
+        Input:  reg: "Dword:00001"
+        Output: reg.type: "Dword", reg.valeur: "00001"
+
+    The regex pattern must contain at least one named group. Groups without names are ignored.
+
+    Type conversion for captured values:
+    - "null", "none", or empty string -> SigmaNull
+    - Integer strings (without leading zeros, except "0") -> SigmaNumber(int)
+    - Float strings (without leading zeros) -> SigmaNumber(float)
+    - All other strings -> SigmaString
+
+    Strings with leading zeros (e.g., "00001") are preserved as SigmaString to avoid
+    losing the leading zero information.
+
+    Attributes:
+        regex (str): Regex pattern with named groups (e.g., (?P<name>pattern)).
+            Default: r"(?P<type>[?A-Za-z0-9_]+):(?P<value>[^\\s=|]+)"
+        field_prefix (str): Prefix for field names. Used as {field_prefix}.{group_name}.
+    """
+
+    regex: str = r"(?P<type>[?A-Za-z0-9_]+):(?P<value>[^\s=|]+)"
+    field_prefix: str = ""
+
+    def __post_init__(self) -> None:
+        if hasattr(super(), '__post_init__'):
+            super().__post_init__()
+        try:
+            self.re = re.compile(self.regex)
+        except re.error as e:
+            raise SigmaRegularExpressionError(
+                f"Regular expression '{self.regex}' is invalid: {str(e)}"
+            ) from e
+        
+        # Validate that regex has at least one named group
+        if not self.re.groupindex:
+            raise SigmaRegularExpressionError(
+                f"Regular expression '{self.regex}' must contain at least one named group"
+            )
+
+    def _convert_value(self, value: str) -> SigmaType:
+        """
+        Convert a string value to the appropriate SigmaType.
+
+        Args:
+            value (str): The string value to convert.
+
+        Returns:
+            SigmaType: The converted value (SigmaNumber, SigmaString, or SigmaNull).
+        """
+        if value.lower() in ("null", "none", ""):
+            return SigmaNull()
+        # Don't convert strings with leading zeros (except "0" alone)
+        if value != "0" and value.startswith("0") and value[1:].isdigit():
+            return SigmaString(value)
+        try:
+            return SigmaNumber(int(value))
+        except ValueError:
+            try:
+                return SigmaNumber(float(value))
+            except ValueError:
+                return SigmaString(value)
+
+    def apply_detection_item(
+        self, detection_item: SigmaDetectionItem
+    ) -> (SigmaDetection | None):
+        """
+        Applies the transformation to detection items whose values match the regex pattern.
+
+        Extracts named capture groups from the regex match and creates one detection item
+        per named group. Each item uses the format: {field_prefix}.{group_name}.
+
+        Args:
+            detection_item (SigmaDetectionItem): The detection item to transform.
+
+        Returns:
+            SigmaDetection | None: A new SigmaDetection with matched items,
+                or None if no values match the pattern.
+        """
+        if not self.field_prefix:
+            return None
+
+        if not isinstance(detection_item.value, list) or not all(
+            isinstance(v, SigmaString) for v in detection_item.value
+        ):
+            return None
+
+        new_items = []
+
+        for val in detection_item.value:
+            plain = val.to_plain()
+            if match := self.re.match(plain):
+                # Create one item per named group
+                for group_name, group_value in match.groupdict().items():
+                    if group_value is None or group_value == "":
+                        continue
+                    
+                    new_items.append(
+                        SigmaDetectionItem(
+                            field=f"{self.field_prefix}.{group_name}",
+                            modifiers=[],
+                            value=[self._convert_value(group_value)],
+                        )
+                    )
+
+        if new_items:
+            return SigmaDetection(
+                detection_items=new_items,
+                item_linking=ConditionAND,
+            )
+        return None

--- a/sigma/processing/transformations/values.py
+++ b/sigma/processing/transformations/values.py
@@ -475,6 +475,10 @@ class ExtractFieldsTransformation(DetectionItemTransformation):
     Strings with leading zeros (e.g., "00001", "03.14") are preserved as SigmaString to avoid
     losing the leading zero information.
 
+    To restrict this transformation to specific fields, use the
+    :class:`~sigma.processing.conditions.IncludeFieldCondition` in the processing item's
+    field_name_conditions instead of a field list attribute on the transformation.
+
     Attributes:
         regex (str): Regex pattern with named groups (e.g., (?P<name>pattern)).
         field_prefix (str | None): Prefix for field names. Used as {field_prefix}.{group_name}.

--- a/sigma/processing/transformations/values.py
+++ b/sigma/processing/transformations/values.py
@@ -446,7 +446,7 @@ class CaseTransformation(StringValueTransformation):
 
 
 @dataclass
-class GenericTypeValueTransformation(DetectionItemTransformation):
+class ExtractFieldsTransformation(DetectionItemTransformation):
     """
     Transforms values matching a regex pattern with named groups into separate detection items.
 
@@ -460,6 +460,10 @@ class GenericTypeValueTransformation(DetectionItemTransformation):
         Input:  reg: "Dword:00001"
         Output: reg.type: "Dword", reg.valeur: "00001"
 
+    Multiple values are each transformed independently. Each value's extracted fields are
+    AND-linked within a nested SigmaDetection, and the outer linking follows the detection
+    item's value_linking (default OR).
+
     The regex pattern must contain at least one named group. Groups without names are ignored.
 
     Type conversion for captured values:
@@ -468,26 +472,22 @@ class GenericTypeValueTransformation(DetectionItemTransformation):
     - Float strings (without leading zeros) -> SigmaNumber(float)
     - All other strings -> SigmaString
 
-    Strings with leading zeros (e.g., "00001") are preserved as SigmaString to avoid
+    Strings with leading zeros (e.g., "00001", "03.14") are preserved as SigmaString to avoid
     losing the leading zero information.
 
     Attributes:
         regex (str): Regex pattern with named groups (e.g., (?P<name>pattern)).
-            Default: r"(?P<type>[?A-Za-z0-9_]+):(?P<value>[^\\s=|]+)"
         field_prefix (str | None): Prefix for field names. Used as {field_prefix}.{group_name}.
             If None, only the group name is used as the field name.
-        field_to_parse (list[str] | None): List of field names to parse. If None, all fields are parsed.
     """
 
-    regex: str = r"(?P<type>[A-Za-z0-9_]+):(?P<value>[^\s=|]+)"
+    regex: str
     field_prefix: str | None = None
-    field_to_parse: list[str] | None = None
 
     def __post_init__(self) -> None:
         if hasattr(super(), "__post_init__"):
             super().__post_init__()  # type: ignore[misc]
 
-        # Validate regex syntax
         try:
             self.re = re.compile(self.regex)
         except re.error as e:
@@ -495,41 +495,21 @@ class GenericTypeValueTransformation(DetectionItemTransformation):
                 f"Regular expression '{self.regex}' is invalid: {str(e)}"
             ) from e
 
-        # Validate that regex has at least one named group
         if not self.re.groupindex:
             raise SigmaRegularExpressionError(
                 f"Regular expression '{self.regex}' must contain at least one named group"
             )
 
-        # Validate no duplicate named groups
         group_names = list(self.re.groupindex.keys())
         if len(group_names) != len(set(group_names)):
             raise SigmaRegularExpressionError(
                 f"Regular expression '{self.regex}' contains duplicate named groups"
             )
 
-        # Validate regex can match at least an empty string or simple pattern
-        try:
-            self.re.match("")
-        except Exception:
-            raise SigmaRegularExpressionError(
-                f"Regular expression '{self.regex}' failed basic validation"
-            )
-
     def _convert_value(self, value: str) -> SigmaType:
-        """
-        Convert a string value to the appropriate SigmaType.
-
-        Args:
-            value (str): The string value to convert.
-
-        Returns:
-            SigmaType: The converted value (SigmaNumber, SigmaString, or SigmaNull).
-        """
         if value.lower() in ("null", "none", ""):
             return SigmaNull()
-        # Don't convert strings with leading zeros (except "0" alone)
-        if value != "0" and value.startswith("0") and value[1:].isdigit():
+        if value != "0" and value.startswith("0"):
             return SigmaString(value)
         try:
             return SigmaNumber(int(value))
@@ -540,34 +520,17 @@ class GenericTypeValueTransformation(DetectionItemTransformation):
                 return SigmaString(value)
 
     def apply_detection_item(self, detection_item: SigmaDetectionItem) -> SigmaDetection | None:
-        """
-        Applies the transformation to detection items whose values match the regex pattern.
-
-        Extracts named capture groups from the regex match and creates one detection item
-        per named group. Each item uses the format: {field_prefix}.{group_name}.
-
-        Args:
-            detection_item (SigmaDetectionItem): The detection item to transform.
-
-        Returns:
-            SigmaDetection | None: A new SigmaDetection with matched items,
-                or None if no values match the pattern.
-        """
-        # Filter by field_to_parse if specified
-        if self.field_to_parse is not None and detection_item.field not in self.field_to_parse:
-            return None
-
         if not isinstance(detection_item.value, list) or not all(
             isinstance(v, SigmaString) for v in detection_item.value
         ):
             return None
 
-        new_items: list[SigmaDetectionItem | SigmaDetection] = []
+        value_detections: list[SigmaDetection] = []
 
         for val in detection_item.value:
             plain = val.to_plain()
+            items: list[SigmaDetectionItem] = []
             if match := self.re.match(plain):
-                # Create one item per named group
                 for group_name, group_value in match.groupdict().items():
                     if group_value is None or group_value == "":
                         continue
@@ -575,7 +538,7 @@ class GenericTypeValueTransformation(DetectionItemTransformation):
                     field_name = (
                         f"{self.field_prefix}.{group_name}" if self.field_prefix else group_name
                     )
-                    new_items.append(
+                    items.append(
                         SigmaDetectionItem(
                             field=field_name,
                             modifiers=[],
@@ -583,9 +546,18 @@ class GenericTypeValueTransformation(DetectionItemTransformation):
                         )
                     )
 
-        if new_items:
-            return SigmaDetection(
-                detection_items=new_items,
-                item_linking=ConditionAND,
-            )
-        return None
+            if items:
+                value_detections.append(
+                    SigmaDetection(detection_items=items, item_linking=ConditionAND)
+                )
+
+        if not value_detections:
+            return None
+
+        if len(value_detections) == 1:
+            return value_detections[0]
+
+        return SigmaDetection(
+            detection_items=value_detections,
+            item_linking=detection_item.value_linking,
+        )

--- a/sigma/processing/transformations/values.py
+++ b/sigma/processing/transformations/values.py
@@ -481,9 +481,9 @@ class GenericTypeValueTransformation(DetectionItemTransformation):
     field_prefix: str = ""
 
     def __post_init__(self) -> None:
-        if hasattr(super(), '__post_init__'):
-            super().__post_init__()
-        
+        if hasattr(super(), "__post_init__"):
+            super().__post_init__()  # type: ignore[misc]
+
         # Validate regex syntax
         try:
             self.re = re.compile(self.regex)
@@ -491,20 +491,20 @@ class GenericTypeValueTransformation(DetectionItemTransformation):
             raise SigmaRegularExpressionError(
                 f"Regular expression '{self.regex}' is invalid: {str(e)}"
             ) from e
-        
+
         # Validate that regex has at least one named group
         if not self.re.groupindex:
             raise SigmaRegularExpressionError(
                 f"Regular expression '{self.regex}' must contain at least one named group"
             )
-        
+
         # Validate no duplicate named groups
         group_names = list(self.re.groupindex.keys())
         if len(group_names) != len(set(group_names)):
             raise SigmaRegularExpressionError(
                 f"Regular expression '{self.regex}' contains duplicate named groups"
             )
-        
+
         # Validate regex can match at least an empty string or simple pattern
         try:
             self.re.match("")
@@ -536,9 +536,7 @@ class GenericTypeValueTransformation(DetectionItemTransformation):
             except ValueError:
                 return SigmaString(value)
 
-    def apply_detection_item(
-        self, detection_item: SigmaDetectionItem
-    ) -> SigmaDetection | None:
+    def apply_detection_item(self, detection_item: SigmaDetectionItem) -> SigmaDetection | None:
         """
         Applies the transformation to detection items whose values match the regex pattern.
 
@@ -560,7 +558,7 @@ class GenericTypeValueTransformation(DetectionItemTransformation):
         ):
             return None
 
-        new_items = []
+        new_items: list[SigmaDetectionItem | SigmaDetection] = []
 
         for val in detection_item.value:
             plain = val.to_plain()
@@ -569,7 +567,7 @@ class GenericTypeValueTransformation(DetectionItemTransformation):
                 for group_name, group_value in match.groupdict().items():
                     if group_value is None or group_value == "":
                         continue
-                    
+
                     new_items.append(
                         SigmaDetectionItem(
                             field=f"{self.field_prefix}.{group_name}",

--- a/sigma/processing/transformations/values.py
+++ b/sigma/processing/transformations/values.py
@@ -455,7 +455,7 @@ class GenericTypeValueTransformation(DetectionItemTransformation):
     - {field_prefix}.{group_name}: captured value
 
     Example:
-        regex = r"(?P<type>Dword):(?P<valeur>[0-9]+)"
+        regex = r"(?P<type>[A-Za-z]+):(?P<valeur>[0-9]+)"
         field_prefix = "reg"
         Input:  reg: "Dword:00001"
         Output: reg.type: "Dword", reg.valeur: "00001"
@@ -477,7 +477,7 @@ class GenericTypeValueTransformation(DetectionItemTransformation):
         field_prefix (str): Prefix for field names. Used as {field_prefix}.{group_name}.
     """
 
-    regex: str = r"(?P<type>[?A-Za-z0-9_]+):(?P<value>[^\s=|]+)"
+    regex: str = r"(?P<type>[A-Za-z0-9_]+):(?P<value>[^\s=|]+)"
     field_prefix: str = ""
 
     def __post_init__(self) -> None:
@@ -521,7 +521,7 @@ class GenericTypeValueTransformation(DetectionItemTransformation):
 
     def apply_detection_item(
         self, detection_item: SigmaDetectionItem
-    ) -> (SigmaDetection | None):
+    ) -> SigmaDetection | None:
         """
         Applies the transformation to detection items whose values match the regex pattern.
 

--- a/sigma/processing/transformations/values.py
+++ b/sigma/processing/transformations/values.py
@@ -483,6 +483,8 @@ class GenericTypeValueTransformation(DetectionItemTransformation):
     def __post_init__(self) -> None:
         if hasattr(super(), '__post_init__'):
             super().__post_init__()
+        
+        # Validate regex syntax
         try:
             self.re = re.compile(self.regex)
         except re.error as e:
@@ -494,6 +496,21 @@ class GenericTypeValueTransformation(DetectionItemTransformation):
         if not self.re.groupindex:
             raise SigmaRegularExpressionError(
                 f"Regular expression '{self.regex}' must contain at least one named group"
+            )
+        
+        # Validate no duplicate named groups
+        group_names = list(self.re.groupindex.keys())
+        if len(group_names) != len(set(group_names)):
+            raise SigmaRegularExpressionError(
+                f"Regular expression '{self.regex}' contains duplicate named groups"
+            )
+        
+        # Validate regex can match at least an empty string or simple pattern
+        try:
+            self.re.match("")
+        except Exception:
+            raise SigmaRegularExpressionError(
+                f"Regular expression '{self.regex}' failed basic validation"
             )
 
     def _convert_value(self, value: str) -> SigmaType:

--- a/sigma/processing/transformations/values.py
+++ b/sigma/processing/transformations/values.py
@@ -474,12 +474,13 @@ class GenericTypeValueTransformation(DetectionItemTransformation):
     Attributes:
         regex (str): Regex pattern with named groups (e.g., (?P<name>pattern)).
             Default: r"(?P<type>[?A-Za-z0-9_]+):(?P<value>[^\\s=|]+)"
-        field_prefix (str): Prefix for field names. Used as {field_prefix}.{group_name}.
+        field_prefix (str | None): Prefix for field names. Used as {field_prefix}.{group_name}.
+            If None, only the group name is used as the field name.
         field_to_parse (list[str] | None): List of field names to parse. If None, all fields are parsed.
     """
 
     regex: str = r"(?P<type>[A-Za-z0-9_]+):(?P<value>[^\s=|]+)"
-    field_prefix: str = ""
+    field_prefix: str | None = None
     field_to_parse: list[str] | None = None
 
     def __post_init__(self) -> None:
@@ -552,9 +553,6 @@ class GenericTypeValueTransformation(DetectionItemTransformation):
             SigmaDetection | None: A new SigmaDetection with matched items,
                 or None if no values match the pattern.
         """
-        if not self.field_prefix:
-            return None
-
         # Filter by field_to_parse if specified
         if self.field_to_parse is not None and detection_item.field not in self.field_to_parse:
             return None
@@ -574,9 +572,12 @@ class GenericTypeValueTransformation(DetectionItemTransformation):
                     if group_value is None or group_value == "":
                         continue
 
+                    field_name = (
+                        f"{self.field_prefix}.{group_name}" if self.field_prefix else group_name
+                    )
                     new_items.append(
                         SigmaDetectionItem(
-                            field=f"{self.field_prefix}.{group_name}",
+                            field=field_name,
                             modifiers=[],
                             value=[self._convert_value(group_value)],
                         )

--- a/sigma/processing/transformations/values.py
+++ b/sigma/processing/transformations/values.py
@@ -533,22 +533,25 @@ class ExtractFieldsTransformation(DetectionItemTransformation):
 
         for val in detection_item.value:
             plain = val.to_plain()
-            items: list[SigmaDetectionItem] = []
-            if match := self.re.match(plain):
-                for group_name, group_value in match.groupdict().items():
-                    if group_value is None or group_value == "":
-                        continue
+            match = self.re.match(plain)
+            if not match:
+                return None
 
-                    field_name = (
-                        f"{self.field_prefix}.{group_name}" if self.field_prefix else group_name
+            items: list[SigmaDetectionItem] = []
+            for group_name, group_value in match.groupdict().items():
+                if group_value is None or group_value == "":
+                    continue
+
+                field_name = (
+                    f"{self.field_prefix}.{group_name}" if self.field_prefix else group_name
+                )
+                items.append(
+                    SigmaDetectionItem(
+                        field=field_name,
+                        modifiers=[],
+                        value=[self._convert_value(group_value)],
                     )
-                    items.append(
-                        SigmaDetectionItem(
-                            field=field_name,
-                            modifiers=[],
-                            value=[self._convert_value(group_value)],
-                        )
-                    )
+                )
 
             if items:
                 value_detections.append(

--- a/sigma/processing/transformations/values.py
+++ b/sigma/processing/transformations/values.py
@@ -529,7 +529,7 @@ class ExtractFieldsTransformation(DetectionItemTransformation):
         ):
             return None
 
-        value_detections: list[SigmaDetection] = []
+        value_detections: list[SigmaDetectionItem | SigmaDetection] = []
 
         for val in detection_item.value:
             plain = val.to_plain()
@@ -537,7 +537,7 @@ class ExtractFieldsTransformation(DetectionItemTransformation):
             if not match:
                 return None
 
-            items: list[SigmaDetectionItem] = []
+            items: list[SigmaDetectionItem | SigmaDetection] = []
             for group_name, group_value in match.groupdict().items():
                 if group_value is None or group_value == "":
                     continue
@@ -562,7 +562,7 @@ class ExtractFieldsTransformation(DetectionItemTransformation):
             return None
 
         if len(value_detections) == 1:
-            return value_detections[0]
+            return cast(SigmaDetection, value_detections[0])
 
         return SigmaDetection(
             detection_items=value_detections,

--- a/tests/test_processing_transformations.py
+++ b/tests/test_processing_transformations.py
@@ -2917,9 +2917,7 @@ def test_strict_mapped_fields_no_pipeline():
 def test_generic_type_value_transformation_single():
     """Test GenericTypeValueTransformation with named groups."""
     transformation = GenericTypeValueTransformation(field_prefix="reg")
-    detection_item = SigmaDetectionItem(
-        "anything", [], [SigmaString("Dword:00001")]
-    )
+    detection_item = SigmaDetectionItem("anything", [], [SigmaString("Dword:00001")])
     result = transformation.apply_detection_item(detection_item)
     assert isinstance(result, SigmaDetection)
     assert len(result.detection_items) == 2
@@ -2933,8 +2931,7 @@ def test_generic_type_value_transformation_single():
 def test_generic_type_value_transformation_custom_named_groups():
     """Test GenericTypeValueTransformation with custom named groups."""
     transformation = GenericTypeValueTransformation(
-        regex=r"(?P<operation>Read|Write):(?P<path>.+)",
-        field_prefix="file_event"
+        regex=r"(?P<operation>Read|Write):(?P<path>.+)", field_prefix="file_event"
     )
     detection_item = SigmaDetectionItem(
         "anything", [], [SigmaString("Read:C:\\Windows\\System32\\cmd.exe")]
@@ -2951,9 +2948,7 @@ def test_generic_type_value_transformation_custom_named_groups():
 def test_generic_type_value_transformation_no_match():
     """Test GenericTypeValueTransformation with no match returns None."""
     transformation = GenericTypeValueTransformation(field_prefix="reg")
-    detection_item = SigmaDetectionItem(
-        "anything", [], [SigmaString("NormalValue")]
-    )
+    detection_item = SigmaDetectionItem("anything", [], [SigmaString("NormalValue")])
     result = transformation.apply_detection_item(detection_item)
     assert result is None
 
@@ -3001,9 +2996,7 @@ def test_generic_type_value_transformation_duplicate_named_groups():
 def test_generic_type_value_transformation_empty_field_prefix():
     """Test GenericTypeValueTransformation returns None if field_prefix is empty."""
     transformation = GenericTypeValueTransformation(field_prefix="")
-    detection_item = SigmaDetectionItem(
-        "anything", [], [SigmaString("Dword:00001")]
-    )
+    detection_item = SigmaDetectionItem("anything", [], [SigmaString("Dword:00001")])
     result = transformation.apply_detection_item(detection_item)
     assert result is None
 
@@ -3011,9 +3004,7 @@ def test_generic_type_value_transformation_empty_field_prefix():
 def test_generic_type_value_transformation_null_value():
     """Test GenericTypeValueTransformation with null value."""
     transformation = GenericTypeValueTransformation(field_prefix="reg")
-    detection_item = SigmaDetectionItem(
-        "anything", [], [SigmaString("Key:null")]
-    )
+    detection_item = SigmaDetectionItem("anything", [], [SigmaString("Key:null")])
     result = transformation.apply_detection_item(detection_item)
     assert isinstance(result, SigmaDetection)
     assert len(result.detection_items) == 2
@@ -3026,9 +3017,7 @@ def test_generic_type_value_transformation_null_value():
 def test_generic_type_value_transformation_number_value():
     """Test GenericTypeValueTransformation with number value."""
     transformation = GenericTypeValueTransformation(field_prefix="reg")
-    detection_item = SigmaDetectionItem(
-        "anything", [], [SigmaString("Key:42")]
-    )
+    detection_item = SigmaDetectionItem("anything", [], [SigmaString("Key:42")])
     result = transformation.apply_detection_item(detection_item)
     assert isinstance(result, SigmaDetection)
     assert len(result.detection_items) == 2
@@ -3042,9 +3031,7 @@ def test_generic_type_value_transformation_number_value():
 def test_generic_type_value_transformation_float_value():
     """Test GenericTypeValueTransformation with float value."""
     transformation = GenericTypeValueTransformation(field_prefix="reg")
-    detection_item = SigmaDetectionItem(
-        "anything", [], [SigmaString("Key:3.14")]
-    )
+    detection_item = SigmaDetectionItem("anything", [], [SigmaString("Key:3.14")])
     result = transformation.apply_detection_item(detection_item)
     assert isinstance(result, SigmaDetection)
     assert len(result.detection_items) == 2
@@ -3058,8 +3045,7 @@ def test_generic_type_value_transformation_float_value():
 def test_generic_type_value_transformation_three_named_groups():
     """Test GenericTypeValueTransformation with three named groups."""
     transformation = GenericTypeValueTransformation(
-        regex=r"(?P<protocol>http|https)://(?P<host>[^/]+)(?P<path>/[^?#]*)?",
-        field_prefix="url"
+        regex=r"(?P<protocol>http|https)://(?P<host>[^/]+)(?P<path>/[^?#]*)?", field_prefix="url"
     )
     detection_item = SigmaDetectionItem(
         "anything", [], [SigmaString("https://example.com/path/to/resource")]
@@ -3079,11 +3065,9 @@ def test_generic_type_value_transformation_mixed_named_unnamed_groups():
     """Test GenericTypeValueTransformation with mixed named and unnamed groups."""
     transformation = GenericTypeValueTransformation(
         regex=r"(?P<type>[A-Za-z]+):(.+)",  # Second group is unnamed, will be ignored
-        field_prefix="reg"
+        field_prefix="reg",
     )
-    detection_item = SigmaDetectionItem(
-        "anything", [], [SigmaString("Dword:00001")]
-    )
+    detection_item = SigmaDetectionItem("anything", [], [SigmaString("Dword:00001")])
     result = transformation.apply_detection_item(detection_item)
     assert isinstance(result, SigmaDetection)
     assert len(result.detection_items) == 1  # Only named group is used
@@ -3094,12 +3078,9 @@ def test_generic_type_value_transformation_mixed_named_unnamed_groups():
 def test_generic_type_value_transformation_empty_domain():
     """Test GenericTypeValueTransformation with empty domain (edge case)."""
     transformation = GenericTypeValueTransformation(
-        regex=r"(?P<domain>[^\\]*)\\(?P<username>.+)",
-        field_prefix="user"
+        regex=r"(?P<domain>[^\\]*)\\(?P<username>.+)", field_prefix="user"
     )
-    detection_item = SigmaDetectionItem(
-        "anything", [], [SigmaString("\\john.doe")]
-    )
+    detection_item = SigmaDetectionItem("anything", [], [SigmaString("\\john.doe")])
     result = transformation.apply_detection_item(detection_item)
     assert isinstance(result, SigmaDetection)
     assert len(result.detection_items) == 1
@@ -3109,12 +3090,8 @@ def test_generic_type_value_transformation_empty_domain():
 
 def test_generic_type_value_transformation_and_condition():
     """Test that extracted items are in a SigmaDetection with AND condition."""
-    transformation = GenericTypeValueTransformation(
-        field_prefix="reg"
-    )
-    detection_item = SigmaDetectionItem(
-        "anything", [], [SigmaString("Dword:00001")]
-    )
+    transformation = GenericTypeValueTransformation(field_prefix="reg")
+    detection_item = SigmaDetectionItem("anything", [], [SigmaString("Dword:00001")])
     result = transformation.apply_detection_item(detection_item)
     assert isinstance(result, SigmaDetection)
     assert result.item_linking == ConditionAND

--- a/tests/test_processing_transformations.py
+++ b/tests/test_processing_transformations.py
@@ -2915,8 +2915,10 @@ def test_strict_mapped_fields_no_pipeline():
 
 
 def test_generic_type_value_transformation_single():
-    """Test GenericTypeValueTransformation with named groups."""
-    transformation = GenericTypeValueTransformation(field_prefix="reg")
+    """Test ExtractFieldsTransformation with named groups."""
+    transformation = ExtractFieldsTransformation(
+        regex=r"(?P<type>[A-Za-z0-9_]+):(?P<value>[^\s=|]+)", field_prefix="reg"
+    )
     detection_item = SigmaDetectionItem("anything", [], [SigmaString("Dword:00001")])
     result = transformation.apply_detection_item(detection_item)
     assert isinstance(result, SigmaDetection)
@@ -2929,8 +2931,8 @@ def test_generic_type_value_transformation_single():
 
 
 def test_generic_type_value_transformation_custom_named_groups():
-    """Test GenericTypeValueTransformation with custom named groups."""
-    transformation = GenericTypeValueTransformation(
+    """Test ExtractFieldsTransformation with custom named groups."""
+    transformation = ExtractFieldsTransformation(
         regex=r"(?P<operation>Read|Write):(?P<path>.+)", field_prefix="file_event"
     )
     detection_item = SigmaDetectionItem(
@@ -2946,56 +2948,70 @@ def test_generic_type_value_transformation_custom_named_groups():
 
 
 def test_generic_type_value_transformation_no_match():
-    """Test GenericTypeValueTransformation with no match returns None."""
-    transformation = GenericTypeValueTransformation(field_prefix="reg")
+    """Test ExtractFieldsTransformation with no match returns None."""
+    transformation = ExtractFieldsTransformation(
+        regex=r"(?P<type>[A-Za-z0-9_]+):(?P<value>[^\s=|]+)", field_prefix="reg"
+    )
     detection_item = SigmaDetectionItem("anything", [], [SigmaString("NormalValue")])
     result = transformation.apply_detection_item(detection_item)
     assert result is None
 
 
 def test_generic_type_value_transformation_multiple_values():
-    """Test GenericTypeValueTransformation with multiple values."""
-    transformation = GenericTypeValueTransformation(field_prefix="reg")
+    """Test ExtractFieldsTransformation with multiple values."""
+    transformation = ExtractFieldsTransformation(
+        regex=r"(?P<type>[A-Za-z0-9_]+):(?P<value>[^\s=|]+)", field_prefix="reg"
+    )
     detection_item = SigmaDetectionItem(
         "anything", [], [SigmaString("Dword:1"), SigmaString("Qword:2")]
     )
     result = transformation.apply_detection_item(detection_item)
     assert isinstance(result, SigmaDetection)
-    assert len(result.detection_items) == 4  # 2 values * 2 groups each
+    assert len(result.detection_items) == 2  # 2 values, each in its own nested detection
+    assert result.item_linking == ConditionOR
     # First value: Dword:1
-    assert result.detection_items[0].field == "reg.type"
-    assert result.detection_items[0].value == [SigmaString("Dword")]
-    assert result.detection_items[1].field == "reg.value"
-    assert result.detection_items[1].value == [SigmaNumber(1)]
+    first = result.detection_items[0]
+    assert isinstance(first, SigmaDetection)
+    assert first.item_linking == ConditionAND
+    assert len(first.detection_items) == 2
+    assert first.detection_items[0].field == "reg.type"
+    assert first.detection_items[0].value == [SigmaString("Dword")]
+    assert first.detection_items[1].field == "reg.value"
+    assert first.detection_items[1].value == [SigmaNumber(1)]
     # Second value: Qword:2
-    assert result.detection_items[2].field == "reg.type"
-    assert result.detection_items[2].value == [SigmaString("Qword")]
-    assert result.detection_items[3].field == "reg.value"
-    assert result.detection_items[3].value == [SigmaNumber(2)]
-    assert result.item_linking == ConditionAND
+    second = result.detection_items[1]
+    assert isinstance(second, SigmaDetection)
+    assert second.item_linking == ConditionAND
+    assert len(second.detection_items) == 2
+    assert second.detection_items[0].field == "reg.type"
+    assert second.detection_items[0].value == [SigmaString("Qword")]
+    assert second.detection_items[1].field == "reg.value"
+    assert second.detection_items[1].value == [SigmaNumber(2)]
 
 
 def test_generic_type_value_transformation_invalid_regex():
-    """Test GenericTypeValueTransformation with invalid regex raises error."""
+    """Test ExtractFieldsTransformation with invalid regex raises error."""
     with pytest.raises(SigmaRegularExpressionError):
-        GenericTypeValueTransformation(regex=r"[invalid")
+        ExtractFieldsTransformation(regex=r"[invalid")
 
 
 def test_generic_type_value_transformation_no_named_groups():
-    """Test GenericTypeValueTransformation raises error if regex has no named groups."""
+    """Test ExtractFieldsTransformation raises error if regex has no named groups."""
     with pytest.raises(SigmaRegularExpressionError, match="must contain at least one named group"):
-        GenericTypeValueTransformation(regex=r"^([A-Za-z]+):([0-9]+)$")
+        ExtractFieldsTransformation(regex=r"^([A-Za-z]+):([0-9]+)$")
 
 
 def test_generic_type_value_transformation_duplicate_named_groups():
-    """Test GenericTypeValueTransformation raises error if regex has duplicate named groups."""
+    """Test ExtractFieldsTransformation raises error if regex has duplicate named groups."""
     with pytest.raises(SigmaRegularExpressionError, match="is invalid"):
-        GenericTypeValueTransformation(regex=r"(?P<type>[A-Za-z]+):(?P<type>[0-9]+)")
+        ExtractFieldsTransformation(regex=r"(?P<type>[A-Za-z]+):(?P<type>[0-9]+)")
 
 
 def test_generic_type_value_transformation_no_field_prefix():
-    """Test GenericTypeValueTransformation with no field_prefix uses group name only."""
-    transformation = GenericTypeValueTransformation()
+    """Test ExtractFieldsTransformation with no field_prefix uses group name only."""
+    transformation = ExtractFieldsTransformation(
+        regex=r"(?P<type>[A-Za-z0-9_]+):(?P<value>[^\s=|]+)"
+    )
     detection_item = SigmaDetectionItem("anything", [], [SigmaString("Dword:00001")])
     result = transformation.apply_detection_item(detection_item)
     assert isinstance(result, SigmaDetection)
@@ -3005,8 +3021,10 @@ def test_generic_type_value_transformation_no_field_prefix():
 
 
 def test_generic_type_value_transformation_null_value():
-    """Test GenericTypeValueTransformation with null value."""
-    transformation = GenericTypeValueTransformation(field_prefix="reg")
+    """Test ExtractFieldsTransformation with null value."""
+    transformation = ExtractFieldsTransformation(
+        regex=r"(?P<type>[A-Za-z0-9_]+):(?P<value>[^\s=|]+)", field_prefix="reg"
+    )
     detection_item = SigmaDetectionItem("anything", [], [SigmaString("Key:null")])
     result = transformation.apply_detection_item(detection_item)
     assert isinstance(result, SigmaDetection)
@@ -3018,8 +3036,10 @@ def test_generic_type_value_transformation_null_value():
 
 
 def test_generic_type_value_transformation_number_value():
-    """Test GenericTypeValueTransformation with number value."""
-    transformation = GenericTypeValueTransformation(field_prefix="reg")
+    """Test ExtractFieldsTransformation with number value."""
+    transformation = ExtractFieldsTransformation(
+        regex=r"(?P<type>[A-Za-z0-9_]+):(?P<value>[^\s=|]+)", field_prefix="reg"
+    )
     detection_item = SigmaDetectionItem("anything", [], [SigmaString("Key:42")])
     result = transformation.apply_detection_item(detection_item)
     assert isinstance(result, SigmaDetection)
@@ -3032,8 +3052,10 @@ def test_generic_type_value_transformation_number_value():
 
 
 def test_generic_type_value_transformation_float_value():
-    """Test GenericTypeValueTransformation with float value."""
-    transformation = GenericTypeValueTransformation(field_prefix="reg")
+    """Test ExtractFieldsTransformation with float value."""
+    transformation = ExtractFieldsTransformation(
+        regex=r"(?P<type>[A-Za-z0-9_]+):(?P<value>[^\s=|]+)", field_prefix="reg"
+    )
     detection_item = SigmaDetectionItem("anything", [], [SigmaString("Key:3.14")])
     result = transformation.apply_detection_item(detection_item)
     assert isinstance(result, SigmaDetection)
@@ -3046,8 +3068,8 @@ def test_generic_type_value_transformation_float_value():
 
 
 def test_generic_type_value_transformation_three_named_groups():
-    """Test GenericTypeValueTransformation with three named groups."""
-    transformation = GenericTypeValueTransformation(
+    """Test ExtractFieldsTransformation with three named groups."""
+    transformation = ExtractFieldsTransformation(
         regex=r"(?P<protocol>http|https)://(?P<host>[^/]+)(?P<path>/[^?#]*)?", field_prefix="url"
     )
     detection_item = SigmaDetectionItem(
@@ -3065,8 +3087,8 @@ def test_generic_type_value_transformation_three_named_groups():
 
 
 def test_generic_type_value_transformation_mixed_named_unnamed_groups():
-    """Test GenericTypeValueTransformation with mixed named and unnamed groups."""
-    transformation = GenericTypeValueTransformation(
+    """Test ExtractFieldsTransformation with mixed named and unnamed groups."""
+    transformation = ExtractFieldsTransformation(
         regex=r"(?P<type>[A-Za-z]+):(.+)",  # Second group is unnamed, will be ignored
         field_prefix="reg",
     )
@@ -3079,8 +3101,8 @@ def test_generic_type_value_transformation_mixed_named_unnamed_groups():
 
 
 def test_generic_type_value_transformation_empty_domain():
-    """Test GenericTypeValueTransformation with empty domain (edge case)."""
-    transformation = GenericTypeValueTransformation(
+    """Test ExtractFieldsTransformation with empty domain (edge case)."""
+    transformation = ExtractFieldsTransformation(
         regex=r"(?P<domain>[^\\]*)\\(?P<username>.+)", field_prefix="user"
     )
     detection_item = SigmaDetectionItem("anything", [], [SigmaString("\\john.doe")])
@@ -3093,7 +3115,9 @@ def test_generic_type_value_transformation_empty_domain():
 
 def test_generic_type_value_transformation_and_condition():
     """Test that extracted items are in a SigmaDetection with AND condition."""
-    transformation = GenericTypeValueTransformation(field_prefix="reg")
+    transformation = ExtractFieldsTransformation(
+        regex=r"(?P<type>[A-Za-z0-9_]+):(?P<value>[^\s=|]+)", field_prefix="reg"
+    )
     detection_item = SigmaDetectionItem("anything", [], [SigmaString("Dword:00001")])
     result = transformation.apply_detection_item(detection_item)
     assert isinstance(result, SigmaDetection)
@@ -3101,35 +3125,16 @@ def test_generic_type_value_transformation_and_condition():
     assert len(result.detection_items) == 2
 
 
-def test_generic_type_value_transformation_field_to_parse():
-    """Test GenericTypeValueTransformation with field_to_parse filter."""
-    transformation = GenericTypeValueTransformation(field_prefix="reg", field_to_parse=["reg"])
-    detection_item = SigmaDetectionItem("reg", [], [SigmaString("Dword:00001")])
+def test_generic_type_value_transformation_leading_zero_float():
+    """Test ExtractFieldsTransformation preserves leading-zero floats as strings."""
+    transformation = ExtractFieldsTransformation(
+        regex=r"(?P<type>[A-Za-z0-9_]+):(?P<value>[^\s=|]+)", field_prefix="reg"
+    )
+    detection_item = SigmaDetectionItem("anything", [], [SigmaString("Key:03.14")])
     result = transformation.apply_detection_item(detection_item)
     assert isinstance(result, SigmaDetection)
     assert len(result.detection_items) == 2
-
-
-def test_generic_type_value_transformation_field_to_parse_wrong_field():
-    """Test GenericTypeValueTransformation returns None for wrong field."""
-    transformation = GenericTypeValueTransformation(field_prefix="reg", field_to_parse=["reg"])
-    detection_item = SigmaDetectionItem("other_field", [], [SigmaString("Dword:00001")])
-    result = transformation.apply_detection_item(detection_item)
-    assert result is None
-
-
-def test_generic_type_value_transformation_field_to_parse_none():
-    """Test GenericTypeValueTransformation with field_to_parse=None parses all fields."""
-    transformation = GenericTypeValueTransformation(field_prefix="reg", field_to_parse=None)
-    detection_item = SigmaDetectionItem("any_field", [], [SigmaString("Dword:00001")])
-    result = transformation.apply_detection_item(detection_item)
-    assert isinstance(result, SigmaDetection)
-    assert len(result.detection_items) == 2
-
-
-def test_generic_type_value_transformation_field_to_parse_empty():
-    """Test GenericTypeValueTransformation with empty field_to_parse returns None."""
-    transformation = GenericTypeValueTransformation(field_prefix="reg", field_to_parse=[])
-    detection_item = SigmaDetectionItem("reg", [], [SigmaString("Dword:00001")])
-    result = transformation.apply_detection_item(detection_item)
-    assert result is None
+    assert result.detection_items[0].field == "reg.type"
+    assert result.detection_items[0].value == [SigmaString("Key")]
+    assert result.detection_items[1].field == "reg.value"
+    assert result.detection_items[1].value == [SigmaString("03.14")]

--- a/tests/test_processing_transformations.py
+++ b/tests/test_processing_transformations.py
@@ -2957,6 +2957,18 @@ def test_generic_type_value_transformation_no_match():
     assert result is None
 
 
+def test_generic_type_value_transformation_partial_match_returns_none():
+    """Test ExtractFieldsTransformation returns None if any value doesn't match."""
+    transformation = ExtractFieldsTransformation(
+        regex=r"(?P<type>[A-Za-z0-9_]+):(?P<value>[^\s=|]+)", field_prefix="reg"
+    )
+    detection_item = SigmaDetectionItem(
+        "anything", [], [SigmaString("Dword:1"), SigmaString("NormalValue")]
+    )
+    result = transformation.apply_detection_item(detection_item)
+    assert result is None
+
+
 def test_generic_type_value_transformation_multiple_values():
     """Test ExtractFieldsTransformation with multiple values."""
     transformation = ExtractFieldsTransformation(

--- a/tests/test_processing_transformations.py
+++ b/tests/test_processing_transformations.py
@@ -2993,12 +2993,15 @@ def test_generic_type_value_transformation_duplicate_named_groups():
         GenericTypeValueTransformation(regex=r"(?P<type>[A-Za-z]+):(?P<type>[0-9]+)")
 
 
-def test_generic_type_value_transformation_empty_field_prefix():
-    """Test GenericTypeValueTransformation returns None if field_prefix is empty."""
-    transformation = GenericTypeValueTransformation(field_prefix="")
+def test_generic_type_value_transformation_no_field_prefix():
+    """Test GenericTypeValueTransformation with no field_prefix uses group name only."""
+    transformation = GenericTypeValueTransformation()
     detection_item = SigmaDetectionItem("anything", [], [SigmaString("Dword:00001")])
     result = transformation.apply_detection_item(detection_item)
-    assert result is None
+    assert isinstance(result, SigmaDetection)
+    assert len(result.detection_items) == 2
+    assert result.detection_items[0].field == "type"
+    assert result.detection_items[1].field == "value"
 
 
 def test_generic_type_value_transformation_null_value():

--- a/tests/test_processing_transformations.py
+++ b/tests/test_processing_transformations.py
@@ -7,7 +7,7 @@ import pytest
 import sigma.processing.transformations as transformations_module
 from sigma.backends.test import TextQueryTestBackend
 from sigma.collection import SigmaCollection
-from sigma.conditions import ConditionOR, SigmaCondition
+from sigma.conditions import ConditionAND, ConditionOR, SigmaCondition
 from sigma.correlations import (
     SigmaCorrelationFieldAlias,
     SigmaCorrelationFieldAliases,
@@ -2912,3 +2912,174 @@ def test_strict_mapped_fields_no_pipeline():
         """)
     with pytest.raises(SigmaTransformationError, match="Pipeline is not set"):
         transformation.apply(rule)
+
+
+def test_generic_type_value_transformation_single():
+    """Test GenericTypeValueTransformation with named groups."""
+    transformation = GenericTypeValueTransformation(field_prefix="reg")
+    detection_item = SigmaDetectionItem(
+        "anything", [], [SigmaString("Dword:00001")]
+    )
+    result = transformation.apply_detection_item(detection_item)
+    assert isinstance(result, SigmaDetection)
+    assert len(result.detection_items) == 2
+    assert result.detection_items[0].field == "reg.type"
+    assert result.detection_items[0].value == [SigmaString("Dword")]
+    assert result.detection_items[1].field == "reg.value"
+    assert result.detection_items[1].value == [SigmaString("00001")]
+    assert result.item_linking == ConditionAND
+
+
+def test_generic_type_value_transformation_custom_named_groups():
+    """Test GenericTypeValueTransformation with custom named groups."""
+    transformation = GenericTypeValueTransformation(
+        regex=r"(?P<operation>Read|Write):(?P<path>.+)",
+        field_prefix="file_event"
+    )
+    detection_item = SigmaDetectionItem(
+        "anything", [], [SigmaString("Read:C:\\Windows\\System32\\cmd.exe")]
+    )
+    result = transformation.apply_detection_item(detection_item)
+    assert isinstance(result, SigmaDetection)
+    assert len(result.detection_items) == 2
+    assert result.detection_items[0].field == "file_event.operation"
+    assert result.detection_items[0].value == [SigmaString("Read")]
+    assert result.detection_items[1].field == "file_event.path"
+    assert result.detection_items[1].value == [SigmaString("C:\\Windows\\System32\\cmd.exe")]
+
+
+def test_generic_type_value_transformation_no_match():
+    """Test GenericTypeValueTransformation with no match returns None."""
+    transformation = GenericTypeValueTransformation(field_prefix="reg")
+    detection_item = SigmaDetectionItem(
+        "anything", [], [SigmaString("NormalValue")]
+    )
+    result = transformation.apply_detection_item(detection_item)
+    assert result is None
+
+
+def test_generic_type_value_transformation_multiple_values():
+    """Test GenericTypeValueTransformation with multiple values."""
+    transformation = GenericTypeValueTransformation(field_prefix="reg")
+    detection_item = SigmaDetectionItem(
+        "anything", [], [SigmaString("Dword:1"), SigmaString("Qword:2")]
+    )
+    result = transformation.apply_detection_item(detection_item)
+    assert isinstance(result, SigmaDetection)
+    assert len(result.detection_items) == 4  # 2 values * 2 groups each
+    # First value: Dword:1
+    assert result.detection_items[0].field == "reg.type"
+    assert result.detection_items[0].value == [SigmaString("Dword")]
+    assert result.detection_items[1].field == "reg.value"
+    assert result.detection_items[1].value == [SigmaNumber(1)]
+    # Second value: Qword:2
+    assert result.detection_items[2].field == "reg.type"
+    assert result.detection_items[2].value == [SigmaString("Qword")]
+    assert result.detection_items[3].field == "reg.value"
+    assert result.detection_items[3].value == [SigmaNumber(2)]
+    assert result.item_linking == ConditionAND
+
+
+def test_generic_type_value_transformation_invalid_regex():
+    """Test GenericTypeValueTransformation with invalid regex raises error."""
+    with pytest.raises(SigmaRegularExpressionError):
+        GenericTypeValueTransformation(regex=r"[invalid")
+
+
+def test_generic_type_value_transformation_no_named_groups():
+    """Test GenericTypeValueTransformation raises error if regex has no named groups."""
+    with pytest.raises(SigmaRegularExpressionError, match="must contain at least one named group"):
+        GenericTypeValueTransformation(regex=r"^([A-Za-z]+):([0-9]+)$")
+
+
+def test_generic_type_value_transformation_empty_field_prefix():
+    """Test GenericTypeValueTransformation returns None if field_prefix is empty."""
+    transformation = GenericTypeValueTransformation(field_prefix="")
+    detection_item = SigmaDetectionItem(
+        "anything", [], [SigmaString("Dword:00001")]
+    )
+    result = transformation.apply_detection_item(detection_item)
+    assert result is None
+
+
+def test_generic_type_value_transformation_null_value():
+    """Test GenericTypeValueTransformation with null value."""
+    transformation = GenericTypeValueTransformation(field_prefix="reg")
+    detection_item = SigmaDetectionItem(
+        "anything", [], [SigmaString("Key:null")]
+    )
+    result = transformation.apply_detection_item(detection_item)
+    assert isinstance(result, SigmaDetection)
+    assert len(result.detection_items) == 2
+    assert result.detection_items[0].field == "reg.type"
+    assert result.detection_items[0].value == [SigmaString("Key")]
+    assert result.detection_items[1].field == "reg.value"
+    assert isinstance(result.detection_items[1].value[0], SigmaNull)
+
+
+def test_generic_type_value_transformation_number_value():
+    """Test GenericTypeValueTransformation with number value."""
+    transformation = GenericTypeValueTransformation(field_prefix="reg")
+    detection_item = SigmaDetectionItem(
+        "anything", [], [SigmaString("Key:42")]
+    )
+    result = transformation.apply_detection_item(detection_item)
+    assert isinstance(result, SigmaDetection)
+    assert len(result.detection_items) == 2
+    assert result.detection_items[0].field == "reg.type"
+    assert result.detection_items[0].value == [SigmaString("Key")]
+    assert result.detection_items[1].field == "reg.value"
+    assert isinstance(result.detection_items[1].value[0], SigmaNumber)
+    assert result.detection_items[1].value[0].number == 42
+
+
+def test_generic_type_value_transformation_float_value():
+    """Test GenericTypeValueTransformation with float value."""
+    transformation = GenericTypeValueTransformation(field_prefix="reg")
+    detection_item = SigmaDetectionItem(
+        "anything", [], [SigmaString("Key:3.14")]
+    )
+    result = transformation.apply_detection_item(detection_item)
+    assert isinstance(result, SigmaDetection)
+    assert len(result.detection_items) == 2
+    assert result.detection_items[0].field == "reg.type"
+    assert result.detection_items[0].value == [SigmaString("Key")]
+    assert result.detection_items[1].field == "reg.value"
+    assert isinstance(result.detection_items[1].value[0], SigmaNumber)
+    assert result.detection_items[1].value[0].number == 3.14
+
+
+def test_generic_type_value_transformation_three_named_groups():
+    """Test GenericTypeValueTransformation with three named groups."""
+    transformation = GenericTypeValueTransformation(
+        regex=r"(?P<protocol>http|https)://(?P<host>[^/]+)(?P<path>/[^?#]*)?",
+        field_prefix="url"
+    )
+    detection_item = SigmaDetectionItem(
+        "anything", [], [SigmaString("https://example.com/path/to/resource")]
+    )
+    result = transformation.apply_detection_item(detection_item)
+    assert isinstance(result, SigmaDetection)
+    assert len(result.detection_items) == 3
+    assert result.detection_items[0].field == "url.protocol"
+    assert result.detection_items[0].value == [SigmaString("https")]
+    assert result.detection_items[1].field == "url.host"
+    assert result.detection_items[1].value == [SigmaString("example.com")]
+    assert result.detection_items[2].field == "url.path"
+    assert result.detection_items[2].value == [SigmaString("/path/to/resource")]
+
+
+def test_generic_type_value_transformation_mixed_named_unnamed_groups():
+    """Test GenericTypeValueTransformation with mixed named and unnamed groups."""
+    transformation = GenericTypeValueTransformation(
+        regex=r"(?P<type>[A-Za-z]+):(.+)",  # Second group is unnamed, will be ignored
+        field_prefix="reg"
+    )
+    detection_item = SigmaDetectionItem(
+        "anything", [], [SigmaString("Dword:00001")]
+    )
+    result = transformation.apply_detection_item(detection_item)
+    assert isinstance(result, SigmaDetection)
+    assert len(result.detection_items) == 1  # Only named group is used
+    assert result.detection_items[0].field == "reg.type"
+    assert result.detection_items[0].value == [SigmaString("Dword")]

--- a/tests/test_processing_transformations.py
+++ b/tests/test_processing_transformations.py
@@ -3096,3 +3096,37 @@ def test_generic_type_value_transformation_and_condition():
     assert isinstance(result, SigmaDetection)
     assert result.item_linking == ConditionAND
     assert len(result.detection_items) == 2
+
+
+def test_generic_type_value_transformation_field_to_parse():
+    """Test GenericTypeValueTransformation with field_to_parse filter."""
+    transformation = GenericTypeValueTransformation(field_prefix="reg", field_to_parse=["reg"])
+    detection_item = SigmaDetectionItem("reg", [], [SigmaString("Dword:00001")])
+    result = transformation.apply_detection_item(detection_item)
+    assert isinstance(result, SigmaDetection)
+    assert len(result.detection_items) == 2
+
+
+def test_generic_type_value_transformation_field_to_parse_wrong_field():
+    """Test GenericTypeValueTransformation returns None for wrong field."""
+    transformation = GenericTypeValueTransformation(field_prefix="reg", field_to_parse=["reg"])
+    detection_item = SigmaDetectionItem("other_field", [], [SigmaString("Dword:00001")])
+    result = transformation.apply_detection_item(detection_item)
+    assert result is None
+
+
+def test_generic_type_value_transformation_field_to_parse_none():
+    """Test GenericTypeValueTransformation with field_to_parse=None parses all fields."""
+    transformation = GenericTypeValueTransformation(field_prefix="reg", field_to_parse=None)
+    detection_item = SigmaDetectionItem("any_field", [], [SigmaString("Dword:00001")])
+    result = transformation.apply_detection_item(detection_item)
+    assert isinstance(result, SigmaDetection)
+    assert len(result.detection_items) == 2
+
+
+def test_generic_type_value_transformation_field_to_parse_empty():
+    """Test GenericTypeValueTransformation with empty field_to_parse returns None."""
+    transformation = GenericTypeValueTransformation(field_prefix="reg", field_to_parse=[])
+    detection_item = SigmaDetectionItem("reg", [], [SigmaString("Dword:00001")])
+    result = transformation.apply_detection_item(detection_item)
+    assert result is None

--- a/tests/test_processing_transformations.py
+++ b/tests/test_processing_transformations.py
@@ -2992,6 +2992,12 @@ def test_generic_type_value_transformation_no_named_groups():
         GenericTypeValueTransformation(regex=r"^([A-Za-z]+):([0-9]+)$")
 
 
+def test_generic_type_value_transformation_duplicate_named_groups():
+    """Test GenericTypeValueTransformation raises error if regex has duplicate named groups."""
+    with pytest.raises(SigmaRegularExpressionError, match="is invalid"):
+        GenericTypeValueTransformation(regex=r"(?P<type>[A-Za-z]+):(?P<type>[0-9]+)")
+
+
 def test_generic_type_value_transformation_empty_field_prefix():
     """Test GenericTypeValueTransformation returns None if field_prefix is empty."""
     transformation = GenericTypeValueTransformation(field_prefix="")

--- a/tests/test_processing_transformations.py
+++ b/tests/test_processing_transformations.py
@@ -2914,7 +2914,7 @@ def test_strict_mapped_fields_no_pipeline():
         transformation.apply(rule)
 
 
-def test_generic_type_value_transformation_single():
+def test_extract_fields_transformation():
     """Test ExtractFieldsTransformation with named groups."""
     transformation = ExtractFieldsTransformation(
         regex=r"(?P<type>[A-Za-z0-9_]+):(?P<value>[^\s=|]+)", field_prefix="reg"
@@ -2930,24 +2930,7 @@ def test_generic_type_value_transformation_single():
     assert result.item_linking == ConditionAND
 
 
-def test_generic_type_value_transformation_custom_named_groups():
-    """Test ExtractFieldsTransformation with custom named groups."""
-    transformation = ExtractFieldsTransformation(
-        regex=r"(?P<operation>Read|Write):(?P<path>.+)", field_prefix="file_event"
-    )
-    detection_item = SigmaDetectionItem(
-        "anything", [], [SigmaString("Read:C:\\Windows\\System32\\cmd.exe")]
-    )
-    result = transformation.apply_detection_item(detection_item)
-    assert isinstance(result, SigmaDetection)
-    assert len(result.detection_items) == 2
-    assert result.detection_items[0].field == "file_event.operation"
-    assert result.detection_items[0].value == [SigmaString("Read")]
-    assert result.detection_items[1].field == "file_event.path"
-    assert result.detection_items[1].value == [SigmaString("C:\\Windows\\System32\\cmd.exe")]
-
-
-def test_generic_type_value_transformation_no_match():
+def test_extract_fields_transformation_no_match():
     """Test ExtractFieldsTransformation with no match returns None."""
     transformation = ExtractFieldsTransformation(
         regex=r"(?P<type>[A-Za-z0-9_]+):(?P<value>[^\s=|]+)", field_prefix="reg"
@@ -2957,19 +2940,7 @@ def test_generic_type_value_transformation_no_match():
     assert result is None
 
 
-def test_generic_type_value_transformation_partial_match_returns_none():
-    """Test ExtractFieldsTransformation returns None if any value doesn't match."""
-    transformation = ExtractFieldsTransformation(
-        regex=r"(?P<type>[A-Za-z0-9_]+):(?P<value>[^\s=|]+)", field_prefix="reg"
-    )
-    detection_item = SigmaDetectionItem(
-        "anything", [], [SigmaString("Dword:1"), SigmaString("NormalValue")]
-    )
-    result = transformation.apply_detection_item(detection_item)
-    assert result is None
-
-
-def test_generic_type_value_transformation_multiple_values():
+def test_extract_fields_transformation_multiple_values():
     """Test ExtractFieldsTransformation with multiple values."""
     transformation = ExtractFieldsTransformation(
         regex=r"(?P<type>[A-Za-z0-9_]+):(?P<value>[^\s=|]+)", field_prefix="reg"
@@ -3001,25 +2972,25 @@ def test_generic_type_value_transformation_multiple_values():
     assert second.detection_items[1].value == [SigmaNumber(2)]
 
 
-def test_generic_type_value_transformation_invalid_regex():
+def test_extract_fields_transformation_invalid_regex():
     """Test ExtractFieldsTransformation with invalid regex raises error."""
     with pytest.raises(SigmaRegularExpressionError):
-        ExtractFieldsTransformation(regex=r"[invalid")
+        ExtractFieldsTransformation(regex=r"invalid")
 
 
-def test_generic_type_value_transformation_no_named_groups():
+def test_extract_fields_transformation_no_named_groups():
     """Test ExtractFieldsTransformation raises error if regex has no named groups."""
     with pytest.raises(SigmaRegularExpressionError, match="must contain at least one named group"):
         ExtractFieldsTransformation(regex=r"^([A-Za-z]+):([0-9]+)$")
 
 
-def test_generic_type_value_transformation_duplicate_named_groups():
+def test_extract_fields_transformation_duplicate_named_groups():
     """Test ExtractFieldsTransformation raises error if regex has duplicate named groups."""
     with pytest.raises(SigmaRegularExpressionError, match="is invalid"):
         ExtractFieldsTransformation(regex=r"(?P<type>[A-Za-z]+):(?P<type>[0-9]+)")
 
 
-def test_generic_type_value_transformation_no_field_prefix():
+def test_extract_fields_transformation_no_field_prefix():
     """Test ExtractFieldsTransformation with no field_prefix uses group name only."""
     transformation = ExtractFieldsTransformation(
         regex=r"(?P<type>[A-Za-z0-9_]+):(?P<value>[^\s=|]+)"
@@ -3032,7 +3003,7 @@ def test_generic_type_value_transformation_no_field_prefix():
     assert result.detection_items[1].field == "value"
 
 
-def test_generic_type_value_transformation_null_value():
+def test_extract_fields_transformation_null_value():
     """Test ExtractFieldsTransformation with null value."""
     transformation = ExtractFieldsTransformation(
         regex=r"(?P<type>[A-Za-z0-9_]+):(?P<value>[^\s=|]+)", field_prefix="reg"
@@ -3047,7 +3018,7 @@ def test_generic_type_value_transformation_null_value():
     assert isinstance(result.detection_items[1].value[0], SigmaNull)
 
 
-def test_generic_type_value_transformation_number_value():
+def test_extract_fields_transformation_number_value():
     """Test ExtractFieldsTransformation with number value."""
     transformation = ExtractFieldsTransformation(
         regex=r"(?P<type>[A-Za-z0-9_]+):(?P<value>[^\s=|]+)", field_prefix="reg"
@@ -3063,7 +3034,7 @@ def test_generic_type_value_transformation_number_value():
     assert result.detection_items[1].value[0].number == 42
 
 
-def test_generic_type_value_transformation_float_value():
+def test_extract_fields_transformation_float_value():
     """Test ExtractFieldsTransformation with float value."""
     transformation = ExtractFieldsTransformation(
         regex=r"(?P<type>[A-Za-z0-9_]+):(?P<value>[^\s=|]+)", field_prefix="reg"
@@ -3079,26 +3050,7 @@ def test_generic_type_value_transformation_float_value():
     assert result.detection_items[1].value[0].number == 3.14
 
 
-def test_generic_type_value_transformation_three_named_groups():
-    """Test ExtractFieldsTransformation with three named groups."""
-    transformation = ExtractFieldsTransformation(
-        regex=r"(?P<protocol>http|https)://(?P<host>[^/]+)(?P<path>/[^?#]*)?", field_prefix="url"
-    )
-    detection_item = SigmaDetectionItem(
-        "anything", [], [SigmaString("https://example.com/path/to/resource")]
-    )
-    result = transformation.apply_detection_item(detection_item)
-    assert isinstance(result, SigmaDetection)
-    assert len(result.detection_items) == 3
-    assert result.detection_items[0].field == "url.protocol"
-    assert result.detection_items[0].value == [SigmaString("https")]
-    assert result.detection_items[1].field == "url.host"
-    assert result.detection_items[1].value == [SigmaString("example.com")]
-    assert result.detection_items[2].field == "url.path"
-    assert result.detection_items[2].value == [SigmaString("/path/to/resource")]
-
-
-def test_generic_type_value_transformation_mixed_named_unnamed_groups():
+def test_extract_fields_transformation_mixed_named_unnamed_groups():
     """Test ExtractFieldsTransformation with mixed named and unnamed groups."""
     transformation = ExtractFieldsTransformation(
         regex=r"(?P<type>[A-Za-z]+):(.+)",  # Second group is unnamed, will be ignored
@@ -3112,7 +3064,7 @@ def test_generic_type_value_transformation_mixed_named_unnamed_groups():
     assert result.detection_items[0].value == [SigmaString("Dword")]
 
 
-def test_generic_type_value_transformation_empty_domain():
+def test_extract_fields_transformation_empty_domain():
     """Test ExtractFieldsTransformation with empty domain (edge case)."""
     transformation = ExtractFieldsTransformation(
         regex=r"(?P<domain>[^\\]*)\\(?P<username>.+)", field_prefix="user"
@@ -3125,19 +3077,7 @@ def test_generic_type_value_transformation_empty_domain():
     assert result.detection_items[0].value == [SigmaString("john.doe")]
 
 
-def test_generic_type_value_transformation_and_condition():
-    """Test that extracted items are in a SigmaDetection with AND condition."""
-    transformation = ExtractFieldsTransformation(
-        regex=r"(?P<type>[A-Za-z0-9_]+):(?P<value>[^\s=|]+)", field_prefix="reg"
-    )
-    detection_item = SigmaDetectionItem("anything", [], [SigmaString("Dword:00001")])
-    result = transformation.apply_detection_item(detection_item)
-    assert isinstance(result, SigmaDetection)
-    assert result.item_linking == ConditionAND
-    assert len(result.detection_items) == 2
-
-
-def test_generic_type_value_transformation_leading_zero_float():
+def test_extract_fields_transformation_leading_zero_float():
     """Test ExtractFieldsTransformation preserves leading-zero floats as strings."""
     transformation = ExtractFieldsTransformation(
         regex=r"(?P<type>[A-Za-z0-9_]+):(?P<value>[^\s=|]+)", field_prefix="reg"

--- a/tests/test_processing_transformations.py
+++ b/tests/test_processing_transformations.py
@@ -3083,3 +3083,33 @@ def test_generic_type_value_transformation_mixed_named_unnamed_groups():
     assert len(result.detection_items) == 1  # Only named group is used
     assert result.detection_items[0].field == "reg.type"
     assert result.detection_items[0].value == [SigmaString("Dword")]
+
+
+def test_generic_type_value_transformation_empty_domain():
+    """Test GenericTypeValueTransformation with empty domain (edge case)."""
+    transformation = GenericTypeValueTransformation(
+        regex=r"(?P<domain>[^\\]*)\\(?P<username>.+)",
+        field_prefix="user"
+    )
+    detection_item = SigmaDetectionItem(
+        "anything", [], [SigmaString("\\john.doe")]
+    )
+    result = transformation.apply_detection_item(detection_item)
+    assert isinstance(result, SigmaDetection)
+    assert len(result.detection_items) == 1
+    assert result.detection_items[0].field == "user.username"
+    assert result.detection_items[0].value == [SigmaString("john.doe")]
+
+
+def test_generic_type_value_transformation_and_condition():
+    """Test that extracted items are in a SigmaDetection with AND condition."""
+    transformation = GenericTypeValueTransformation(
+        field_prefix="reg"
+    )
+    detection_item = SigmaDetectionItem(
+        "anything", [], [SigmaString("Dword:00001")]
+    )
+    result = transformation.apply_detection_item(detection_item)
+    assert isinstance(result, SigmaDetection)
+    assert result.item_linking == ConditionAND
+    assert len(result.detection_items) == 2


### PR DESCRIPTION
## Description

Add a generic transformation to extract fields from values using regex with named groups.

This transformation parses values matching a regex pattern with named capture groups and creates separate detection items for each group.

## Features

- **Named group extraction**: Extract fields using regex named groups `(?P<name>pattern)`
- **Optional field prefix**: Prefix extracted field names with `{field_prefix}.{group_name}`
- **Field filtering**: Restrict transformation to specific fields via `field_to_parse`
- **Type conversion**: Automatic conversion to SigmaType (null, int, float, string)
- **Robust validation**: Comprehensive regex validation (syntax, named groups, duplicates)

## Example Usage

### Basic Usage (without field_prefix)
```python
transformation = GenericTypeValueTransformation()
# regex: (?P<type>[A-Za-z0-9_]+):(?P<value>[^\s=|]+)
# Input:  "Dword:00001"
# Output: type: "Dword", value: "00001"
```

### With Field Prefix
```python
transformation = GenericTypeValueTransformation(field_prefix="reg")
# Input:  "Dword:00001"
# Output: reg.type: "Dword", reg.value: "00001"
```

### Custom Regex (domain\username parsing)
```python
transformation = GenericTypeValueTransformation(
    regex=r"(?P<domain>[^\\]*)\\(?P<username>.+)",
    field_prefix="user"
)
# Input:  "contoso\john.doe"
# Output: user.domain: "contoso", user.username: "john.doe"
```

### Empty Domain Edge Case
```python
transformation = GenericTypeValueTransformation(
    regex=r"(?P<domain>[^\\]*)\\(?P<username>.+)",
    field_prefix="user"
)
# Input:  "\john.doe"
# Output: user.username: "john.doe" (empty domain is skipped)
```

### URL Parsing
```python
transformation = GenericTypeValueTransformation(
    regex=r"(?P<protocol>http|https)://(?P<host>[^/]+)(?P<path>/[^?#]*)?",
    field_prefix="url"
)
# Input:  "https://example.com/path/to/resource"
# Output: url.protocol: "https", url.host: "example.com", url.path: "/path/to/resource"
```

### Field Filtering
```python
transformation = GenericTypeValueTransformation(
    field_prefix="reg",
    field_to_parse=["reg", "other_field"]
)
# Only transforms "reg" and "other_field" fields
```

## YAML Configuration

```yaml
processing:
  name: Extract type:value
  priority: 20
  items:
    - id: extract_type_value
      type: generic_type_value
      field_prefix: "reg"
```

## Validation

- Regex must contain at least one named group
- No duplicate named groups allowed
- Comprehensive regex syntax validation
- Empty `field_to_parse` returns `None`

## Tests

19 new tests covering:
- Single/multiple matches
- Custom named groups
- No match scenarios
- Multiple values
- Invalid regex
- Duplicate named groups
- Empty field_prefix (optional)
- Null/number/float value conversion
- Three named groups
- Mixed named/unnamed groups
- Empty domain edge case
- AND condition verification
- Field filtering (field_to_parse)

All 168 tests passing.

## Type Conversion

- `"null"`, `"none"`, or empty string → `SigmaNull`
- Integer strings (without leading zeros) → `SigmaNumber(int)`
- Float strings → `SigmaNumber(float)`
- All other strings → `SigmaString`
- Leading zeros preserved as `SigmaString` (e.g., `"00001"` stays string)
