### PR TITLE
Fix ControlCharacterValidator off-by-one so 0x1F is flagged

### DIFF
--- a/sigma/validators/core/values.py
+++ b/sigma/validators/core/values.py
@@ -74,7 +74,7 @@ class ControlCharacterValidator(SigmaStringValueValidator):
     """
 
     def validate_string(self, value: SigmaString) -> list[SigmaValidationIssue]:
-        if any((ord(c) < 31 for s in value.s for c in (s if isinstance(s, str) else ""))):
+        if any((ord(c) < 32 for s in value.s for c in (s if isinstance(s, str) else ""))):
             return [ControlCharacterIssue([self.rule], value)]
         else:
             return []

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -155,6 +155,32 @@ def test_validator_control_characters():
     assert validator.validate(rule) == [ControlCharacterIssue([rule], SigmaString("\temp"))]
 
 
+def test_validator_control_characters_c0_range_boundary():
+    # The C0 control range is 0x00-0x1F inclusive, so 0x1F (Unit Separator) must be
+    # flagged while 0x20 (space, the first printable character) must not.
+    validator = ControlCharacterValidator()
+    rule = SigmaRule.from_yaml("""
+    title: Test
+    status: test
+    logsource:
+        category: test
+    detection:
+        sel:
+            field1: placeholder
+        condition: sel
+    """)
+    detection_item = rule.detection.detections["sel"].detection_items[0]
+
+    # 0x1F is a control character and must be reported.
+    us_value = SigmaString("value\x1fend")
+    detection_item.value = [us_value]
+    assert validator.validate(rule) == [ControlCharacterIssue([rule], us_value)]
+
+    # 0x20 (space) is printable and must not be reported.
+    detection_item.value = [SigmaString("value end")]
+    assert validator.validate(rule) == []
+
+
 def test_validator_control_characters_correlation_rule(correlation_rule):
     validator = ControlCharacterValidator()
     assert validator.validate(correlation_rule) == []


### PR DESCRIPTION
The ControlCharacterValidator doesn't flag ASCII 0x1F (the Unit Separator). The C0 control range is 0x00 to 0x1F inclusive, but the check uses `ord(c) < 31`, so 0x1F slips through even though 0x1E and tab are caught. This bumps the bound to `< 32` so the whole C0 range is covered.

I also added a small boundary test asserting that 0x1F is reported and 0x20 (space) is not. The full suite still passes.
