### PR TITLE
feat: add UnboundFieldTransformation for keyword detections

### DIFF
--- a/sigma/processing/transformations/__init__.py
+++ b/sigma/processing/transformations/__init__.py
@@ -16,6 +16,7 @@ from sigma.processing.transformations.fields import (
     FieldPrefixMappingTransformation,
     RemoveFieldTransformation,
     SetFieldTransformation,
+    UnboundFieldTransformation,
 )
 from sigma.processing.transformations.meta import NestedProcessingTransformation
 from sigma.processing.transformations.placeholder import (
@@ -48,6 +49,7 @@ transformations: dict[str, Type[Transformation]] = {
     "field_name_mapping": FieldMappingTransformation,
     "field_name_prefix_mapping": FieldPrefixMappingTransformation,
     "field_name_transform": FieldFunctionTransformation,
+    "unbound_field": UnboundFieldTransformation,
     "drop_detection_item": DropDetectionItemTransformation,
     "hashes_fields": HashesFieldsDetectionItemTransformation,
     "field_name_suffix": AddFieldnameSuffixTransformation,
@@ -83,6 +85,7 @@ __all__ = [
     "FieldMappingTransformation",
     "FieldPrefixMappingTransformation",
     "FieldFunctionTransformation",
+    "UnboundFieldTransformation",
     "DropDetectionItemTransformation",
     "HashesFieldsDetectionItemTransformation",
     "AddFieldnameSuffixTransformation",

--- a/sigma/processing/transformations/fields.py
+++ b/sigma/processing/transformations/fields.py
@@ -1,18 +1,14 @@
-import dataclasses
-from sigma.conditions import ConditionOR
 from typing import (
-    Optional,
-    Union,
     Callable,
 )
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from sigma.correlations import SigmaCorrelationRule
 from sigma.exceptions import SigmaProcessingItemError
 from sigma.processing.transformations.base import (
     FieldMappingTransformationBase,
     PreprocessingTransformation,
 )
-from sigma.rule import SigmaRule, SigmaDetection, SigmaDetectionItem
+from sigma.rule import SigmaRule
 
 
 @dataclass
@@ -23,6 +19,24 @@ class FieldMappingTransformation(FieldMappingTransformationBase):
 
     def apply_field_name(self, field: str | None) -> None | str | list[str]:
         return self.mapping.get(field)
+
+
+@dataclass
+class UnboundFieldTransformation(FieldMappingTransformationBase):
+    """
+    Assign a field name to unbound (keyword) detection items.
+    When a detection item has no field (field=None), it is assigned the specified field.
+    """
+
+    field: str
+
+    def apply_field_name(self, field: str | None) -> str | None:
+        if self.field == "":
+            raise SigmaProcessingItemError(
+                "UnboundFieldTransformation: field cannot be an empty string."
+            )
+
+        return self.field if field is None else None
 
 
 @dataclass

--- a/tests/test_processing_transformations.py
+++ b/tests/test_processing_transformations.py
@@ -576,6 +576,73 @@ def test_field_mapping_none_preserves_existing_wildcards(dummy_pipeline):
     assert "*other*" in values_str
 
 
+def test_unbound_field_transformation(dummy_pipeline):
+    """Test that UnboundFieldTransformation sets field for unbound detections."""
+    rule = SigmaRule.from_dict(
+        {
+            "title": "Test",
+            "logsource": {"category": "test"},
+            "detection": {
+                "keywords": ["a", "b"],
+                "condition": "keywords",
+            },
+        }
+    )
+
+    transformation = UnboundFieldTransformation(field="message")
+    transformation.set_pipeline(dummy_pipeline)
+    transformation.apply(rule)
+
+    detection_item = rule.detection.detections["keywords"].detection_items[0]
+    assert detection_item.field == "message"
+
+
+def test_unbound_field_transformation_preserves_bound_fields(dummy_pipeline):
+    """Test that UnboundFieldTransformation doesn't modify bound fields."""
+    rule = SigmaRule.from_dict(
+        {
+            "title": "Test",
+            "logsource": {"category": "test"},
+            "detection": {
+                "selection": {"user": "admin", "process": "cmd.exe"},
+                "condition": "selection",
+            },
+        }
+    )
+
+    transformation = UnboundFieldTransformation(field="message")
+    transformation.set_pipeline(dummy_pipeline)
+    transformation.apply(rule)
+
+    detection_items = rule.detection.detections["selection"].detection_items
+    fields = [item.field for item in detection_items]
+    assert "user" in fields
+    assert "process" in fields
+
+
+def test_unbound_field_transformation_rejects_empty_field(dummy_pipeline):
+    """Test that UnboundFieldTransformation raises error for empty field."""
+    from sigma.exceptions import SigmaProcessingItemError
+
+    # Test: empty field in transformation config when applied
+    rule = SigmaRule.from_dict(
+        {
+            "title": "Test",
+            "logsource": {"category": "test"},
+            "detection": {
+                "keywords": ["a", "b"],
+                "condition": "keywords",
+            },
+        }
+    )
+
+    transformation = UnboundFieldTransformation(field="")
+    transformation.set_pipeline(dummy_pipeline)
+
+    with pytest.raises(SigmaProcessingItemError, match="field cannot be an empty string"):
+        transformation.apply(rule)
+
+
 @pytest.fixture
 def field_function_transformation():
     return FieldFunctionTransformation(


### PR DESCRIPTION
Add a dedicated transformation to assign a field name to unbound (keyword) detection items. When a detection item has no field (field=None), it is assigned the configured field value.

- UnboundFieldTransformation in sigma/processing/transformations/fields.py
- Registered as 'unbound_field' in transformations dict
- 3 tests: normal case, preserves bound fields, rejects empty field
- Clean up unused imports in fields.py