### PR TITLE
Raise SigmaPipelineConditionError in match_field_in_value when no condition is defined

### DIFF
--- a/sigma/processing/pipeline.py
+++ b/sigma/processing/pipeline.py
@@ -638,6 +638,10 @@ class ProcessingItem(ProcessingItemBase):
                 field_name_cond_result = self.field_name_condition_linking(
                     [condition.match_value(value) for condition in self.field_name_conditions]
                 )
+            else:  # no field name condition expression or linking defined
+                raise SigmaPipelineConditionError(
+                    "No field name condition expression or linking defined for processing item."
+                )
             if self.field_name_condition_negation:
                 field_name_cond_result = not field_name_cond_result
 

--- a/tests/test_processing_pipeline.py
+++ b/tests/test_processing_pipeline.py
@@ -33,7 +33,7 @@ from sigma.processing.transformations import (
 )
 from sigma.rule import SigmaRule, SigmaDetectionItem
 from sigma.exceptions import SigmaConfigurationError, SigmaPipelineConditionError, SigmaTypeError
-from sigma.types import SigmaString
+from sigma.types import SigmaString, SigmaFieldReference
 
 
 @dataclass
@@ -709,6 +709,18 @@ def test_processingitem_match_field_name_with_expression_false():
         ),
     )
     assert not processing_item.match_field_name("field")
+
+
+def test_processingitem_match_field_in_value_no_condition():
+    processing_item = ProcessingItem(
+        transformation=TransformationAppend(s="Test"),
+        field_name_conditions=[FieldNameConditionTrue(dummy="test-true")],
+        field_name_condition_linking=any,
+    )
+    processing_item.field_name_condition_expression = None
+    processing_item.field_name_condition_linking = None
+    with pytest.raises(SigmaPipelineConditionError, match="No field name condition"):
+        processing_item.match_field_in_value(SigmaFieldReference("field"))
 
 
 def test_processingitem_rule_condition_no_list_or_dict():


### PR DESCRIPTION
Fixes #504.

`DetectionItemCondition.match_field_in_value` was missing the `else` branch that its siblings `match_detection_item` and `match_field_name` both have. When neither `field_name_condition_expression` nor `field_name_condition_linking` is set, `field_name_cond_result` was never assigned and the method raised a bare `UnboundLocalError` instead of the `SigmaPipelineConditionError` callers expect. This adds the same guard the two sibling methods use, and a regression test.