### PR TITLE
fix(processing): compile filter regex at init and raise SigmaConfigurationError on invalid pattern

### DIFF
--- a/sigma/processing/transformations/external.py
+++ b/sigma/processing/transformations/external.py
@@ -66,6 +66,9 @@ class ExternalSourceBaseTransformation(BasePlaceholderTransformation):
     allow_external_sources: bool = False
 
     _values_cache: list[str] | None = field(init=False, default=None, repr=False, compare=False)
+    _filter_pattern: re.Pattern[str] | None = field(
+        init=False, default=None, repr=False, compare=False
+    )
 
     def __post_init__(self) -> None:
         if self.format not in SUPPORTED_FORMATS:
@@ -73,6 +76,11 @@ class ExternalSourceBaseTransformation(BasePlaceholderTransformation):
                 f"Unknown external source format '{self.format}'. "
                 f"Supported formats: {', '.join(SUPPORTED_FORMATS)}."
             )
+        if self.filter is not None:
+            try:
+                self._filter_pattern = re.compile(self.filter)
+            except re.error as e:
+                raise SigmaConfigurationError(f"Invalid regex in 'filter': {e}") from e
         super().__post_init__()
 
     def _external_sources_allowed(self) -> bool:
@@ -130,9 +138,8 @@ class ExternalSourceBaseTransformation(BasePlaceholderTransformation):
 
     def _parse_plaintext(self, data: str) -> list[str]:
         values = [line for line in (line.strip() for line in data.splitlines()) if line]
-        if self.filter:
-            pattern = re.compile(self.filter)
-            values = [v for v in values if pattern.search(v)]
+        if self._filter_pattern is not None:
+            values = [v for v in values if self._filter_pattern.search(v)]
         return values
 
     def _parse_csv(self, data: str) -> list[str]:
@@ -164,9 +171,8 @@ class ExternalSourceBaseTransformation(BasePlaceholderTransformation):
                 if col_idx < len(csv_row):
                     values.append(csv_row[col_idx])
 
-        if self.filter:
-            pattern = re.compile(self.filter)
-            values = [v for v in values if pattern.search(v)]
+        if self._filter_pattern is not None:
+            values = [v for v in values if self._filter_pattern.search(v)]
         return values
 
     def _parse_json(self, data: str) -> list[str]:

--- a/tests/test_external_placeholder_transformations.py
+++ b/tests/test_external_placeholder_transformations.py
@@ -150,6 +150,21 @@ class TestExternalValueSourceParsers:
         )
         assert t._parse_data(data) == ["keep_this", "keep_too"]
 
+    def test_filter_invalid_regex_raises_at_init(self):
+        with pytest.raises(SigmaConfigurationError, match="Invalid regex in 'filter'"):
+            FilePlaceholderTransformation(
+                path=PLAINTEXT_FILE,
+                allow_external_sources=True,
+                filter="[unclosed",
+            )
+
+    def test_filter_pattern_compiled_at_init(self):
+        t = FilePlaceholderTransformation(
+            path=PLAINTEXT_FILE, allow_external_sources=True, filter=r"^\d+"
+        )
+        assert t._filter_pattern is not None
+        assert t._filter_pattern.pattern == r"^\d+"
+
     def test_json_jq_expression(self):
         data = json.dumps({"values": ["a", "b", "c"]})
         t = FilePlaceholderTransformation(


### PR DESCRIPTION
Closes #509.

## Summary

The `filter` field on `ExternalSourceBaseTransformation` was recompiled on every `_parse_plaintext` and `_parse_csv` call. A malformed pattern raised a bare `re.error` at parse time rather than `SigmaConfigurationError` at pipeline-load time — inconsistent with every other regex field in pySigma and breaking callers that catch `SigmaError`.

This PR adds a `_filter_pattern` private field, compiles the regex once in `__post_init__` (raising `SigmaConfigurationError` on bad input), and reuses it in both parse methods. The change mirrors the existing `reg_filter_output` design exactly.

## Changes

- `sigma/processing/transformations/external.py`
  - New `_filter_pattern: re.Pattern[str] | None` dataclass field
  - `__post_init__`: compile `filter` eagerly; raise `SigmaConfigurationError` on bad regex
  - `_parse_plaintext`, `_parse_csv`: use `_filter_pattern` instead of `re.compile(self.filter)`

- `tests/test_external_placeholder_transformations.py`
  - `test_filter_invalid_regex_raises_at_init` — bad pattern → `SigmaConfigurationError` at construction
  - `test_filter_pattern_compiled_at_init` — valid pattern → `_filter_pattern` set and correct

All 59 existing external-placeholder tests continue to pass.