### PR TITLE
fix(transformations): raise SigmaValueError instead of bare Exception in HashesFieldsDetectionItemTransformation

### DIFF
--- a/sigma/processing/transformations/values.py
+++ b/sigma/processing/transformations/values.py
@@ -96,7 +96,7 @@ class HashesFieldsDetectionItemTransformation(DetectionItemTransformation):
             algo_dict = self._parse_hash_values(cast(list[SigmaString], values))
 
             if not algo_dict:
-                raise Exception(
+                raise SigmaValueError(
                     f"No valid hash algorithm found in Hashes field. Please use one of the following: {', '.join(self.valid_hash_algos)}"
                 )
 

--- a/tests/test_processing_transformations.py
+++ b/tests/test_processing_transformations.py
@@ -2553,7 +2553,7 @@ def test_hashes_transformation_drop_algo_prefix():
 
 def test_hashes_transformation_invalid_hash(hashes_transformation):
     detection_item = SigmaDetectionItem("Hashes", [], [SigmaString("INVALID=123456")])
-    with pytest.raises(Exception, match="No valid hash algorithm found"):
+    with pytest.raises(SigmaValueError, match="No valid hash algorithm found"):
         hashes_transformation.apply_detection_item(detection_item)
 
 


### PR DESCRIPTION
Closes #510.

## Summary

`HashesFieldsDetectionItemTransformation.apply_detection_item` raised a bare `Exception` when no valid hash algorithm was found. Every other error path in pySigma raises a `SigmaError` subclass; the bare `Exception` broke callers catching `SigmaError` or `SigmaValueError` and caused unexpected crashes instead of structured pipeline errors.

`SigmaValueError` is already imported in the file and is the appropriate type — the error originates from an unrecognised value in a detection item.

## Changes

- `sigma/processing/transformations/values.py` — line 99: `raise Exception(...)` → `raise SigmaValueError(...)`
- `tests/test_processing_transformations.py` — `test_hashes_transformation_invalid_hash`: assert `SigmaValueError` instead of the base `Exception` class

All 19 hashes-transformation tests pass.