### PR TITLE
fix(postprocessing): raise SigmaConfigurationError on invalid regex in ReplaceQueryTransformation

### DIFF
--- a/sigma/processing/conditions/fields.py
+++ b/sigma/processing/conditions/fields.py
@@ -25,7 +25,15 @@ class IncludeFieldCondition(FieldNameProcessingCondition):
         if self.mode == "plain":
             pass
         elif self.mode == "re":
-            self.patterns = [re.compile(field) for field in self.fields]
+            compiled = []
+            for field_pattern in self.fields:
+                try:
+                    compiled.append(re.compile(field_pattern))
+                except re.error as e:
+                    raise SigmaConfigurationError(
+                        f"Regular expression '{field_pattern}' in field name condition is invalid: {e}"
+                    ) from e
+            self.patterns = compiled
         else:
             raise SigmaConfigurationError(
                 f"Invalid field name matching mode '{self.mode}', supported types are 'plain' or 're'."

--- a/sigma/processing/postprocessing.py
+++ b/sigma/processing/postprocessing.py
@@ -134,7 +134,12 @@ class ReplaceQueryTransformation(QueryPostprocessingTransformation):
     replacement: str
 
     def __post_init__(self) -> None:
-        self.re = re.compile(self.pattern)
+        try:
+            self.re = re.compile(self.pattern)
+        except re.error as e:
+            raise SigmaConfigurationError(
+                f"Regular expression '{self.pattern}' is invalid: {str(e)}"
+            ) from e
 
     def apply(self, rule: SigmaRule | SigmaCorrelationRule, query: Any) -> Any:
         super().apply(rule, query)

--- a/tests/test_postprocessing_transformations.py
+++ b/tests/test_postprocessing_transformations.py
@@ -84,6 +84,11 @@ def test_replace_query_transformation(dummy_pipeline, sigma_rule):
     assert transformation.apply(sigma_rule, 'field="value"') == 'field="replaced"'
 
 
+def test_replace_query_transformation_invalid_regex():
+    with pytest.raises(SigmaConfigurationError, match="Regular expression .* is invalid"):
+        ReplaceQueryTransformation("[invalid", "x")
+
+
 @pytest.fixture
 def nested_query_postprocessing_transformation(dummy_pipeline):
     transformation = NestedQueryPostprocessingTransformation(

--- a/tests/test_processing_conditions.py
+++ b/tests/test_processing_conditions.py
@@ -405,6 +405,11 @@ def test_include_field_condition_wrong_type():
         IncludeFieldCondition(["field", "otherfield"], "invalid")
 
 
+def test_include_field_condition_invalid_re():
+    with pytest.raises(SigmaConfigurationError, match="Regular expression .* is invalid"):
+        IncludeFieldCondition(["[invalid"], "re")
+
+
 def test_exclude_field_condition_match():
     assert ExcludeFieldCondition(["field", "otherfield"]).match_field_name("field") == False
 


### PR DESCRIPTION
## Problem

Two places in the codebase call `re.compile()` on user-supplied patterns without wrapping the call, so an invalid regex raises a bare `re.error` from the stdlib instead of the `SigmaConfigurationError` callers expect.

Every other transformation/condition that compiles a user-supplied pattern already wraps it:

| Location | Error raised |
|---|---|
| `ReplaceStringTransformation` | `SigmaRegularExpressionError` |
| `ExtractFieldsTransformation` | `SigmaRegularExpressionError` |
| `ExternalSourceBaseTransformation` | `SigmaConfigurationError` |
| `MatchValueCondition` | `SigmaRegularExpressionError` |
| **`ReplaceQueryTransformation`** | **bare `re.error`** ← inconsistent |
| **`IncludeFieldCondition` (mode=re)** | **bare `re.error`** ← inconsistent |

## Fix

Both fixed in this PR:

1. **`sigma/processing/postprocessing.py`** — `ReplaceQueryTransformation.__post_init__`: wrap `re.compile(self.pattern)` → raise `SigmaConfigurationError`

2. **`sigma/processing/conditions/fields.py`** — `IncludeFieldCondition.__post_init__` (also covers `ExcludeFieldCondition`, which inherits `__post_init__`): replace the bare list comprehension with a loop that wraps each `re.compile()` → raise `SigmaConfigurationError`

## Changes

- `sigma/processing/postprocessing.py`
- `sigma/processing/conditions/fields.py`
- `tests/test_postprocessing_transformations.py`: `test_replace_query_transformation_invalid_regex`
- `tests/test_processing_conditions.py`: `test_include_field_condition_invalid_re`

## Testing

All 1521 existing tests continue to pass; both new tests confirm the fixes.

Closes #522