### PR TITLE
Raise SigmaValueError for non-finite SigmaNumber values

### DIFF
--- a/sigma/types.py
+++ b/sigma/types.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from dataclasses import InitVar, dataclass, field
 from enum import Enum, auto
 from ipaddress import IPv4Network, IPv6Network, ip_network
-from math import inf
+from math import inf, isfinite
 from typing import (
     ClassVar,
     Type,
@@ -669,13 +669,15 @@ class SigmaNumber(SigmaType):
 
     def __post_init__(self, init_number: Any) -> None:
         try:  # Only use float number if it can't be represented as int.
-            i = int(init_number)
             f = float(init_number)
+            if not isfinite(f):
+                raise ValueError("Invalid number")
+            i = int(init_number)
             if i == f:
                 self.number = i
             else:
                 self.number = f
-        except ValueError as e:
+        except (ValueError, OverflowError) as e:
             raise SigmaValueError("Invalid number") from e
 
     def __str__(self) -> str:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -569,6 +569,12 @@ def test_number_invalid():
         SigmaNumber("test")
 
 
+def test_number_invalid_non_finite():
+    for value in [float("inf"), float("-inf"), float("nan")]:
+        with pytest.raises(SigmaValueError, match="Invalid number"):
+            SigmaNumber(value)
+
+
 def test_field_reference():
     assert SigmaFieldReference("field").field == "field"
 


### PR DESCRIPTION
SigmaNumber.__post_init__ converted float('inf'), float('-inf') and float('nan') via int() without handling the resulting OverflowError, crashing rule parsing with a raw OverflowError instead of a SigmaValueError. This is reachable from rule files, since .inf/.nan are valid YAML floats (detection.py:151 passes them to sigma_type()).

Convert the value to float first and reject non-finite numbers with SigmaValueError('Invalid number'). Also catch OverflowError so oversized integers that overflow float conversion are reported as invalid numbers instead of raising unhandled.