### PR TITLE
fix(rule): validate types of level, tags and related meta fields

### DIFF
--- a/sigma/rule/attributes.py
+++ b/sigma/rule/attributes.py
@@ -152,6 +152,10 @@ class SigmaRelated:
 
         list_ret: list[SigmaRelatedItem] = []
         for v in val:
+            if not isinstance(v, dict):
+                raise sigma_exceptions.SigmaRelatedError(
+                    "Sigma related items must be maps with an id and type field"
+                )
             if "id" not in v.keys():
                 raise sigma_exceptions.SigmaRelatedError("Sigma related must have an id field")
             elif "type" not in v.keys():

--- a/sigma/rule/base.py
+++ b/sigma/rule/base.py
@@ -208,14 +208,21 @@ class SigmaRuleBase:
         # Rule level validation
         rule_level = rule.get("level")
         if rule_level is not None:
-            try:
-                rule_level = SigmaLevel[rule_level.upper()]
-            except KeyError:
+            if not isinstance(rule_level, str):
                 errors.append(
                     sigma_exceptions.SigmaLevelError(
-                        f"'{ rule_level }' is not a valid Sigma rule level", source=source
+                        "Sigma rule level must be a string", source=source
                     )
                 )
+            else:
+                try:
+                    rule_level = SigmaLevel[rule_level.upper()]
+                except KeyError:
+                    errors.append(
+                        sigma_exceptions.SigmaLevelError(
+                            f"'{ rule_level }' is not a valid Sigma rule level", source=source
+                        )
+                    )
 
         # Rule status validation
         rule_status = rule.get("status")
@@ -248,6 +255,13 @@ class SigmaRuleBase:
                 )
             else:
                 for tag in tags:
+                    if not isinstance(tag, str):
+                        errors.append(
+                            sigma_exceptions.SigmaTagError(
+                                "Sigma rule tags must be a list of strings", source=source
+                            )
+                        )
+                        continue
                     try:
                         rule_tags.append(SigmaRuleTag.from_str(tag))
                     except sigma_exceptions.SigmaValueError as e:

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -1276,6 +1276,74 @@ def test_sigmarule_collect_errors():
     }
 
 
+@pytest.mark.parametrize(
+    ("rule", "expected_error"),
+    [
+        (
+            """
+    title: Test
+    level: 123
+    logsource:
+        product: windows
+    detection:
+        selection_1:
+            fieldA: valueA
+        condition: selection_1
+    """,
+            sigma_exceptions.SigmaLevelError,
+        ),
+        (
+            """
+    title: Test
+    tags:
+        - 123
+    logsource:
+        product: windows
+    detection:
+        selection_1:
+            fieldA: valueA
+        condition: selection_1
+    """,
+            sigma_exceptions.SigmaTagError,
+        ),
+        (
+            """
+    title: Test
+    related:
+        - foo
+    logsource:
+        product: windows
+    detection:
+        selection_1:
+            fieldA: valueA
+        condition: selection_1
+    """,
+            sigma_exceptions.SigmaRelatedError,
+        ),
+    ],
+)
+def test_sigmarule_meta_field_type_errors_collected(rule, expected_error):
+    """Non-string level, non-string tag and non-map related items must be reported
+    as validation errors, not crash with an AttributeError."""
+    parsed = SigmaRule.from_yaml(rule, collect_errors=True)
+    assert expected_error in {error.__class__ for error in parsed.errors}
+
+
+def test_sigmarule_meta_field_type_errors_raised():
+    """Without collect_errors the first recognized error is raised as a SigmaError."""
+    with pytest.raises(sigma_exceptions.SigmaLevelError):
+        SigmaRule.from_yaml("""
+        title: Test
+        level: 123
+        logsource:
+            product: windows
+        detection:
+            selection_1:
+                fieldA: valueA
+            condition: selection_1
+        """)
+
+
 def test_sigmarule_no_logsource():
     with pytest.raises(
         sigma_exceptions.SigmaLogsourceError, match="must have a log source.*test.yml"


### PR DESCRIPTION
## What changed

Rule meta fields with unexpected YAML types crashed parsing with an unhandled `AttributeError` instead of producing a proper `SigmaError` validation error:

- `level: 123` → `AttributeError: 'int' object has no attribute 'upper'` (`sigma/rule/base.py`)
- `tags: [123]` → `AttributeError: 'int' object has no attribute 'split'` (`sigma/rule/base.py`)
- `related: [foo]` → `AttributeError: 'str' object has no attribute 'keys'` (`sigma/rule/attributes.py`)

`status` already had an `isinstance(str)` guard; `level`, `tags` and `related` did not, so malformed rules bypassed the `collect_errors` machinery and crashed callers (e.g. sigma-cli batch rule checks) with a raw exception instead of a per-rule validation error. All three now emit `SigmaLevelError` / `SigmaTagError` / `SigmaRelatedError`, collected or raised like every other rule error.

## How verified

- Added tests: malformed `level`, `tags`, `related` are collected as the expected error classes with `collect_errors=True`, and raised as `SigmaLevelError` without it.
- `pytest`: 1524 passed (2 pre-existing failures in `tests/test_plugins.py` are subprocess install tests unrelated to this change).
- `black --check .` and `mypy`: clean.