### PR TITLE
fix(rule): raise SigmaError for non-string related fields and non-map detection

### DIFF
--- a/sigma/rule/attributes.py
+++ b/sigma/rule/attributes.py
@@ -124,14 +124,20 @@ class SigmaRelatedItem:
     @classmethod
     def from_dict(cls, value: dict[str, str]) -> "SigmaRelatedItem":
         """Returns Related item from dict with fields."""
+        if not isinstance(value["id"], str):
+            raise sigma_exceptions.SigmaRelatedError(
+                "Sigma related identifier must be a string UUID"
+            )
         try:
             id = UUID(value["id"])
         except ValueError:
             raise sigma_exceptions.SigmaRelatedError("Sigma related identifier must be an UUID")
 
+        if not isinstance(value["type"], str):
+            raise sigma_exceptions.SigmaRelatedError("Sigma related type must be a string")
         try:
             type = SigmaRelatedType[value["type"].upper()]
-        except:
+        except KeyError:
             raise sigma_exceptions.SigmaRelatedError(
                 f"{value['type']} is not a Sigma related valid type"
             )

--- a/sigma/rule/rule.py
+++ b/sigma/rule/rule.py
@@ -68,6 +68,13 @@ class SigmaRule(SigmaRuleBase, ProcessingItemTrackingMixin):
                     "Sigma rule must have a detection definitions", source=source
                 )
             )
+        except TypeError:
+            detections = EmptySigmaDetections()
+            errors.append(
+                sigma_exceptions.SigmaDetectionError(
+                    "Sigma detection must be a valid YAML map", source=source
+                )
+            )
         except SigmaError as e:
             detections = EmptySigmaDetections()
             errors.append(e)

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -1295,6 +1295,38 @@ def test_sigmarule_no_detections():
         )
 
 
+def test_sigmarule_detection_not_map():
+    with pytest.raises(
+        sigma_exceptions.SigmaDetectionError, match="detection must be a valid YAML map.*test.yml"
+    ):
+        SigmaRule.from_dict(
+            {
+                "title": "azerty",
+                "logsource": {"category": "category-id"},
+                "detection": "hello",
+            },
+            source=sigma_exceptions.SigmaRuleLocation("test.yml"),
+        )
+
+
+def test_sigmarule_detection_not_map_collect_errors():
+    sigma_rule = SigmaRule.from_dict(
+        {
+            "title": "azerty",
+            "logsource": {"category": "category-id"},
+            "detection": ["hello", "world"],
+        },
+        source=sigma_exceptions.SigmaRuleLocation("test.yml"),
+        collect_errors=True,
+    )
+    assert sigma_rule.errors == [
+        sigma_exceptions.SigmaDetectionError(
+            "Sigma detection must be a valid YAML map",
+            source=sigma_exceptions.SigmaRuleLocation("test.yml"),
+        )
+    ]
+
+
 def test_sigmarule_none_to_list():
     sigma_rule = SigmaRule(
         title="Test",
@@ -1678,6 +1710,44 @@ def test_invalid_related_list():
     related:
         id: 08fbc97d-0a2f-491c-ae21-8ffcfd3174e9
         types: derived
+    status: test
+    logsource:
+        category: test
+    detection:
+        sel:
+            field: value
+        condition: sel
+    """)
+
+
+def test_invalid_related_id_type():
+    with pytest.raises(
+        sigma_exceptions.SigmaRelatedError, match="Sigma related identifier must be a string UUID"
+    ):
+        SigmaRule.from_yaml("""
+    title: Test
+    related:
+        - id: 123
+          type: derived
+    status: test
+    logsource:
+        category: test
+    detection:
+        sel:
+            field: value
+        condition: sel
+    """)
+
+
+def test_invalid_related_type_type():
+    with pytest.raises(
+        sigma_exceptions.SigmaRelatedError, match="Sigma related type must be a string"
+    ):
+        SigmaRule.from_yaml("""
+    title: Test
+    related:
+        - id: 08fbc97d-0a2f-491c-ae21-8ffcfd3174e9
+          type: 123
     status: test
     logsource:
         category: test


### PR DESCRIPTION
Fixes malformed rules crashing with raw exceptions instead of proper validation errors.

## What's broken

`SigmaRule.from_yaml`/`from_dict` is supposed to validate malformed rules and produce `SigmaError`s (collected via `collect_errors=True` or raised otherwise). Three malformed-rule shapes bypass that machinery and crash callers (e.g. sigma-cli batch checks) with raw exceptions:

1. `related: [{id: 123, type: derived}]` — non-string `id` inside an otherwise valid map.
   `UUID(123)` raises `AttributeError` (only `ValueError` is caught), so the rule crashes instead of raising `SigmaRelatedError`.

2. `related: [{id: ..., type: 123}]` — non-string `type` hits `.upper()` under a bare `except`, producing a `SigmaRelatedError` only by accident of the catch-all.

3. `detection: hello` (or `detection: [a, b]`, `detection: 123`) — a non-map `detection` section.
   `detections["condition"]` raises `TypeError`, which is not caught in `SigmaRule.from_dict`, so parsing crashes even with `collect_errors=True`.

## Fix

* `SigmaRelatedItem.from_dict` validates that `id` and `type` are strings before use, raising `SigmaRelatedError` (mirrors the `isinstance` style of the earlier type-validation fix for `related: [foo]`).
* `SigmaRule.from_dict` gains an `except TypeError` branch for the detection block, mirroring the existing guard in `SigmaFilter.from_dict` ("Sigma filter must be a dictionary").

All three shapes now yield a collected/raised `SigmaDetectionError` / `SigmaRelatedError` like every other rule error.

## Tests

Added 3 regression tests in `tests/test_rule.py`:

* `test_invalid_related_id_type` — `id: 123` raises `SigmaRelatedError`
* `test_invalid_related_type_type` — `type: 123` raises `SigmaRelatedError`
* `test_sigmarule_detection_not_map` / `test_sigmarule_detection_not_map_collect_errors` — non-map detection raises / collects `SigmaDetectionError`

## Verification

* `pytest tests/test_rule.py` — 148 passed
* Full suite — 1525 passed, 1 skipped (2 pre-existing plugin-install failures need network/pip)
* `mypy` — clean (66 files)
* `black --check` — clean