### PR TITLE
fix(types): transparent slicing for zero stop and friendlier YAML errors

### DIFF
--- a/sigma/rule/base.py
+++ b/sigma/rule/base.py
@@ -27,7 +27,7 @@ class SigmaYAMLLoader(yaml.CSafeLoader):
         for k, v in node.value:
             key = self.construct_object(k, deep=deep)
             if key in keys:
-                raise yaml.error.YAMLError("Duplicate key '{k}'")
+                raise yaml.error.YAMLError(f"Duplicate key '{key}'")
             else:
                 keys.add(key)
 
@@ -398,6 +398,8 @@ class SigmaRuleBase:
     def from_yaml(cls: type[Self], rule: str, collect_errors: bool = False) -> Self:
         """Convert YAML input string with single document into SigmaRule object."""
         parsed_rule = yaml.load(rule, SigmaYAMLLoader)
+        if parsed_rule is None:
+            parsed_rule = {}
         return cls.from_dict(parsed_rule, collect_errors)
 
     def to_dict(self: Self) -> dict[str, Any]:

--- a/sigma/types.py
+++ b/sigma/types.py
@@ -200,7 +200,7 @@ class SigmaString(SigmaType):
             if idx.step is not None:
                 raise IndexError("SigmaString slice index with step is not allowed")
             start = idx.start or 0
-            end = idx.stop or inf
+            end = idx.stop if idx.stop is not None else inf
         else:
             raise TypeError("SigmaString indices must be integers or slices")
 

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -1507,6 +1507,36 @@ def test_sigmarule_fromyaml_duplicate_key():
         """)
 
 
+def test_sigmarule_fromyaml_empty():
+    with pytest.raises(sigma_exceptions.SigmaError):
+        SigmaRule.from_yaml("   \n# only a comment\n")
+
+
+def test_sigmarule_fromyaml_empty_collect_errors():
+    sigma_rule = SigmaRule.from_yaml("   \n# only a comment\n", collect_errors=True)
+    assert len(sigma_rule.errors) > 0
+    assert all(isinstance(e, sigma_exceptions.SigmaError) for e in sigma_rule.errors)
+
+
+def test_sigmarule_fromyaml_duplicate_key_reports_key():
+    with pytest.raises(YAMLError, match="Duplicate key 'selection'"):
+        SigmaRule.from_yaml("""
+        title: Test
+        id: 9a6cafa7-1481-4e64-89a1-1f69ed08618c
+        logsource:
+            category: process_creation
+            product: windows
+        detection:
+            selection:
+                CommandLine|contains: test.exe
+            selection:
+                - CommandLine|contains: test.exe
+                - CommandLine|contains: cmd.exe
+            condition: 1 of them
+        level: low
+        """)
+
+
 def test_sigmarule_to_dict(sigma_rule: SigmaRule):
     assert sigma_rule.to_dict() == {
         "title": "Test",

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -469,6 +469,14 @@ def test_string_index_slice_empty_result(sigma_string):
     assert sigma_string[4:2] == SigmaString("")
 
 
+def test_string_index_slice_zero_stop(sigma_string):
+    assert sigma_string[:0] == SigmaString("")
+    assert sigma_string[0:0] == SigmaString("")
+    assert sigma_string[1:0] == SigmaString("")
+    assert sigma_string[1:1] == SigmaString("")
+    assert sigma_string[-1:0] == SigmaString("")
+
+
 def test_string_index_slice_start_after_end(sigma_string):
     assert sigma_string[100:] == SigmaString("")
 


### PR DESCRIPTION
Three small, independent fixes around rule parsing and `SigmaString` semantics.

## 1. `SigmaString` slicing with a zero stop index (sigma/types.py)

`SigmaString.__getitem__` used `end = idx.stop or inf`, mapping the falsy integer `0` to `inf`. As a result `s[:0]`, `s[0:0]`, `s[1:0]` and `s[1:1]` returned non-empty slices instead of the empty `SigmaString`, unlike plain `str`:

```python
>>> SigmaString("abc")[1:0]  == "abc"[1:0]  # was: SigmaString(['bc']) != SigmaString('')
False
```

Fix: `end = idx.stop if idx.stop is not None else inf`.

## 2. Empty/comment-only YAML documents crash with raw `AttributeError` (sigma/rule/base.py)

`SigmaRule.from_yaml("")` or a comment-only document parses to `None` and `from_dict(None)` crashes with `AttributeError: 'NoneType' object has no attribute 'get'`. Ruleset directories routinely contain leftover empty `.yml` files, so batch tooling blows up with a raw exception. Empty documents now go through the normal validation path and produce collected/raised `SigmaError`s like `SigmaTitleError`.

## 3. Duplicate-key error prints the literal `{k}` (sigma/rule/base.py)

`raise yaml.error.YAMLError("Duplicate key '{k}'")` is missing the `f` prefix, so the diagnostic literally says `Duplicate key '{k}'` instead of naming the offending key. Now reports e.g. `Duplicate key 'selection'`.

## Tests

* `test_string_index_slice_zero_stop` (tests/test_types.py) — `[:0]`, `[0:0]`, `[1:0]`, `[1:1]`, `[-1:0]` all return `SigmaString("")`
* `test_sigmarule_fromyaml_empty` / `test_sigmarule_fromyaml_empty_collect_errors` (tests/test_rule.py)
* `test_sigmarule_fromyaml_duplicate_key_reports_key` — asserts the key name appears in the message

## Verification

* `pytest tests/test_types.py tests/test_rule.py` — 296 passed
* `mypy` — clean (66 files)
* `black --check` — clean