### PR TITLE
fix(correlations): reject invalid and non-positive timespans

### DIFF
--- a/sigma/correlations.py
+++ b/sigma/correlations.py
@@ -329,30 +329,38 @@ class SigmaCorrelationTimespan:
     count: int = field(init=False)
     unit: str = field(init=False)
 
+    timespan_re: ClassVar[re.Pattern[str]] = re.compile("(?P<count>[0-9]+)(?P<unit>[smhdwMy])")
+    unit_seconds: ClassVar[dict[str, int]] = {
+        "s": 1,
+        "m": 60,
+        "h": 3600,
+        "d": 86400,
+        "w": 604800,
+        "M": 2629746,
+        "y": 31556952,
+    }
+
     def __post_init__(self: Self) -> None:
         """
         Parses a string representing a time span and stores the equivalent number of seconds.
 
+        A time span must be a positive integer count followed by one of the unit characters
+        s, m, h, d, w, M or y.
+
         Raises:
             sigma_exceptions.SigmaTimespanError: If the given time span is invalid.
         """
-        try:
-            self.count = int(self.spec[:-1])
-            self.unit = self.spec[-1]
-            self.seconds = (
-                self.count
-                * {
-                    "s": 1,
-                    "m": 60,
-                    "h": 3600,
-                    "d": 86400,
-                    "w": 604800,
-                    "M": 2629746,
-                    "y": 31556952,
-                }[self.unit]
-            )
-        except (ValueError, KeyError):
+        parsed = self.timespan_re.fullmatch(self.spec) if isinstance(self.spec, str) else None
+        if parsed is None:
             raise sigma_exceptions.SigmaTimespanError(f"Timespan '{ self.spec }' is invalid.")
+        count = int(parsed.group("count"))
+        if count <= 0:
+            raise sigma_exceptions.SigmaTimespanError(
+                f"Timespan '{ self.spec }' must be greater than zero."
+            )
+        self.count = count
+        self.unit = parsed.group("unit")
+        self.seconds = self.count * self.unit_seconds[self.unit]
 
 
 @dataclass

--- a/tests/test_correlations.py
+++ b/tests/test_correlations.py
@@ -292,6 +292,68 @@ def test_correlation_timespan():
     assert timespan.seconds == 600
 
 
+@pytest.mark.parametrize(
+    ("spec", "count", "unit", "seconds"),
+    [
+        ("30s", 30, "s", 30),
+        ("10m", 10, "m", 600),
+        ("2h", 2, "h", 7200),
+        ("3d", 3, "d", 259200),
+        ("4w", 4, "w", 2419200),
+        ("5M", 5, "M", 13148730),
+        ("6y", 6, "y", 189341712),
+    ],
+)
+def test_correlation_timespan_units(spec, count, unit, seconds):
+    timespan = SigmaCorrelationTimespan(spec)
+    assert timespan.count == count
+    assert timespan.unit == unit
+    assert timespan.seconds == seconds
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        "-10m",  # negative count
+        "+10m",  # sign is not part of the specification
+        " 10m",  # leading whitespace
+        "10m ",  # trailing whitespace
+        "1_0m",  # Python integer literal underscore separator
+        "\u0661\u0662m",  # non-ASCII digits
+        "10x",  # unknown unit
+        "10",  # unit missing
+        "m",  # count missing
+        "",  # empty
+        10,  # not a string
+    ],
+)
+def test_correlation_invalid_timespan_spec(spec):
+    with pytest.raises(SigmaTimespanError, match="is invalid"):
+        SigmaCorrelationTimespan(spec)
+
+
+@pytest.mark.parametrize("spec", ["0s", "0m", "00h"])
+def test_correlation_zero_timespan(spec):
+    with pytest.raises(SigmaTimespanError, match="must be greater than zero"):
+        SigmaCorrelationTimespan(spec)
+
+
+def test_correlation_negative_timespan_rule():
+    with pytest.raises(SigmaTimespanError, match="Timespan '-5m' is invalid."):
+        SigmaCorrelationRule.from_dict(
+            {
+                "title": "Negative time span",
+                "correlation": {
+                    "type": "event_count",
+                    "rules": "failed_login",
+                    "group-by": ["user"],
+                    "timespan": "-5m",
+                    "condition": {"gte": 10},
+                },
+            }
+        )
+
+
 def test_correlation_without_timespan():
     with pytest.raises(SigmaCorrelationRuleError, match="Sigma correlation rule without timespan"):
         SigmaCorrelationRule.from_dict(


### PR DESCRIPTION
**Note: Small Bug**

## Problem

`SigmaCorrelationTimespan.__post_init__` reads the count with `int(self.spec[:-1])`. `int()`
accepts far more than the
[specification](https://github.com/SigmaHQ/sigma-specification/blob/main/specification/sigma-correlation-rules-specification.md)
allows, which says a timespan is "number + letter (in lowercase)".

All of these are accepted on `main` without any error:

| `timespan` | parsed as | problem |
|---|---|---|
| `-5m` | `seconds = -300` | a window running backwards |
| `0m` | `seconds = 0` | a window with no width |
| `+5m` | `seconds = 300` | the sign is not in the specification |
| `' 5m'` | `seconds = 300` | leading whitespace |
| `5_0m` | `seconds = 3000` | Python's digit separator, not Sigma syntax |
| `١٢m` | `seconds = 720` | `int()` accepts non-ASCII digits |

The rule converts fine and the bad value is passed on to the backend. With
`pysigma-backend-splunk`, `-5m` becomes `| bin _time span=-5m`. Splunk 9.4 refuses to run that
search, and its error message talks about sub-second units rather than the minus sign, so the
user ends up debugging Splunk instead of their rule. I tested this on a Splunk 9.4 instance:
`-5m`, `0m`, `5_0m`, `' 5m'` and `١٢m` all fail there, while a `5m` control works.

This is easiest to hit when correlation rules are generated by a script, where a timespan can
come out as zero or negative and nobody reads the value before it is converted.

## Fix

Check the value when it is parsed instead of relying on `int()`:

- the spec must fully match `[0-9]+[smhdwMy]` (`[0-9]` and not `\d`, so non-ASCII digits are
  rejected)
- the count must be greater than zero
- anything else raises `SigmaTimespanError`

Doing this at parse time means the invalid object is never created.

Notes:

- `w`, `M` and `y` still work as before.
- `timespan: 5` (a number rather than a string) used to raise
  `TypeError: 'int' object is not subscriptable`. It now raises `SigmaTimespanError`.
- `+5m` is now rejected. Some backends accept it, so this is a small change in behaviour. I can
  keep allowing it if you prefer.

## Tests

In `tests/test_correlations.py`:

- all supported units with their expected `count`, `unit` and `seconds`
- every invalid value listed above, plus a missing unit, a missing count, an empty string and a
  non-string input
- `0s`, `0m` and `00h` for the zero case
- one `SigmaCorrelationRule.from_dict` test with `timespan: -5m`

`black --check`, `mypy` and the full test suite (1561 passed, 1 skipped) pass locally.
