### PR TITLE
fix(types): keep escaped special characters plain in SigmaString slices

### DIFF
--- a/sigma/types.py
+++ b/sigma/types.py
@@ -231,7 +231,11 @@ class SigmaString(SigmaType):
                 if e_len > start:
                     # else:
                     if end < e_len:  # end lies within this string part
-                        return self.__class__(e[start : cast(int, end)])
+                        s = self.__class__()
+                        s.s = [
+                            e[start : cast(int, end)]
+                        ]  # don't re-parse the cut-out substring: plain wildcard characters from escaped sequences would be interpreted as special characters again
+                        return s
                     else:  # end lies behind the current string part
                         result.append(e[start:])
                         # end -= start

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -441,6 +441,22 @@ def test_string_index_slice_start_and_end_in_same_string_part(sigma_string):
     assert sigma_string[2:4] == SigmaString("es")
 
 
+def test_string_index_slice_cut_out_escaped_wildcard(sigma_string):
+    """The escaped wildcard at index 9 is a plain character and must not become special when cut out by a slice."""
+    assert sigma_string[9:11] == SigmaString("\\*i")
+
+
+def test_string_index_slice_cut_out_only_escaped_wildcard():
+    s = SigmaString("a\\*b")
+    assert s[1:2] == SigmaString("\\*")
+
+
+def test_string_index_slice_cut_out_escaped_wildcard_cased():
+    s = SigmaCasedString("a\\*b")
+    assert type(s[1:2]) is SigmaCasedString
+    assert s[1:2] == SigmaCasedString("\\*")
+
+
 def test_string_index_slice_negative_end(sigma_string):
     assert sigma_string[3:-1] == SigmaString("st*Str\\*ing")
 


### PR DESCRIPTION
When a slice ends inside a plain string part, the cut-out substring was passed through the `SigmaString` constructor again. That re-parses the raw text, so a wildcard character that was escaped in the original value — and is therefore a plain character of that part — turns into a real special character after slicing.

Reproducer:

```python
from sigma.types import SigmaString

s = SigmaString(r"a\*b")   # escaped star: matches the literal string a*b
s[1:2]                      # before: WILDCARD_MULTI, after: the literal *
```

This is reachable from backend conversion: `sigma/conversion/base.py` strips the first/last character of detection values with `[1:]` / `[:-1]` and calls `contains_special()` on the result to decide between wildcard and plain handling, so an escaped `*` or `?` at a value boundary currently makes a literal value look like a wildcard one.

The fix builds the slice result from the existing part structure instead of re-parsing, the same way the multi-part path below already does. All existing slicing tests pass unchanged; I added cases that cut around the escaped wildcard of the `*Test*Str\\*ing*` fixture, including the cased variant.

Verified locally: `pytest` (152 passed in tests/test_types.py, full suite green), `mypy` and `black --check` all clean.