### PR TITLE
fix(types): stop IPv6 CIDR expansion from collapsing byte-aligned prefixes

### DIFF
--- a/sigma/types.py
+++ b/sigma/types.py
@@ -922,19 +922,21 @@ class SigmaCIDRExpression(NoPlainConversionMixin, SigmaType):
             ):  # Generate all the subnetworks where the prefix ends at the next 4 bit boundary
                 first_addr = str(subnet_v6.network_address)
                 last_addr = str(subnet_v6.broadcast_address)
-                wildcard_required = False  # There's the possibility that no wildcard is required at all if the prefix is /128 (e.g. localhost)
-                for i in range(
-                    len(first_addr)
-                ):  # Determine the first char that differs between the first and last network address of the network. This is the location where the wildcard has to be placed.
-                    if first_addr[i] != last_addr[i]:
-                        wildcard_required = True
-                        break  # location found
-                if wildcard_required:
+                if (
+                    first_addr == last_addr
+                ):  # The /128 case - single address, use network_address not network (avoid "::1/128" literal)
+                    patterns.append(str(subnet_v6.network_address))
+                else:
+                    for i in range(
+                        len(first_addr)
+                    ):  # Determine the first char that differs between the first and last network address of the network. This is the location where the wildcard has to be placed.
+                        if first_addr[i] != last_addr[i]:
+                            break  # location found
+                    else:  # The compressed broadcast address only extends the compressed network address (e.g. 2001:db8::/64): the wildcard belongs directly after the network address
+                        i = len(first_addr)
                     patterns.append(
                         str(subnet_v6)[:i] + wildcard
                     )  # Generate pattern by cutting of at first difference
-                else:  # The /128 case - single address, use network_address not network (avoid "::1/128" literal)
-                    patterns.append(str(subnet_v6.network_address))
         return patterns
 
 

--- a/sigma/types.py
+++ b/sigma/types.py
@@ -880,6 +880,11 @@ class SigmaCIDRExpression(NoPlainConversionMixin, SigmaType):
 
         Setting wildcard to None indicates that this feature is not need and the query language handles CIDR notation properly.
         """
+        if (
+            wildcard is None
+        ):  # The query language handles CIDR notation properly: return the network itself in CIDR notation
+            return [str(self.network)]
+
         patterns = []
         if isinstance(
             self.network, IPv4Network

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -835,6 +835,31 @@ def test_cidr_expand_ipv6_56():
     assert SigmaCIDRExpression("1234:5678:0:ab00::/56").expand() == ["1234:5678:0:ab*"]
 
 
+def test_cidr_expand_ipv6_64():
+    """The compressed broadcast address only extends the compressed network address: the wildcard belongs directly after it."""
+    assert SigmaCIDRExpression("2001:db8::/64").expand() == ["2001:db8::*"]
+
+
+def test_cidr_expand_ipv6_112():
+    assert SigmaCIDRExpression("2001:db8::/112").expand() == ["2001:db8::*"]
+
+
+def test_cidr_expand_ipv6_120():
+    assert SigmaCIDRExpression("2001:db8::/120").expand() == ["2001:db8::*"]
+
+
+def test_cidr_expand_ipv6_128():
+    assert SigmaCIDRExpression("2001:db8::1/128").expand() == ["2001:db8::1"]
+
+
+def test_cidr_expand_ipv6_without_wildcard():
+    assert SigmaCIDRExpression("2001:db8::/64").expand(wildcard=None) == ["2001:db8::/64"]
+
+
+def test_cidr_expand_ipv4_without_wildcard():
+    assert SigmaCIDRExpression("192.168.1.0/24").expand(wildcard=None) == ["192.168.1.0/24"]
+
+
 def test_cidr_expand_ipv6_58():
     assert SigmaCIDRExpression("1234:5678:0:ab00::/58").expand() == [
         "1234:5678:0:ab0*",


### PR DESCRIPTION
The IPv6 branch of `SigmaCIDRExpression.expand()` searched the compressed network and broadcast address strings for the first differing character and treated *no difference found* as the /128 case. For compressed IPv6 that assumption breaks, because the broadcast address often just extends the network address as a string:

- network of `2001:db8::/64`: `2001:db8::`
- broadcast: `2001:db8::ffff:ffff:ffff:ffff`

No differing character is found within the network address, so the whole /64 collapsed to the pattern `2001:db8::`, which matches exactly one address instead of the subnet:

```python
SigmaCIDRExpression("2001:db8::/64").expand()
# before: ['2001:db8::']        (matches only the network address itself)
# after:  ['2001:db8::*']
```

The same collapse hit /112, /120 and every other prefix where the compressed broadcast only appends characters (e.g. `2001:db8::/112`, `2001:db8::/120`). The fix keeps the real /128 special case (`network_address == broadcast_address`) and otherwise places the wildcard directly after the compressed network address when the difference lies beyond it. Outputs for all previously tested prefixes (`::/0`, `1234:5678:0:ab00::/56`, `fe80::/10` and the IPv4 cases) are unchanged.

Second commit: the docstring documents `wildcard=None` as "the query language handles CIDR notation properly", but both branches crashed with a `TypeError` in that case. It now returns the network in CIDR notation as documented.

Verified locally: `pytest` (all green incl. the new /64, /112, /120, /128 and wildcard=None cases), `mypy` and `black --check` clean.